### PR TITLE
apply storage_limit: 0 if estimated storage is negative

### DIFF
--- a/src/Signer.ts
+++ b/src/Signer.ts
@@ -290,7 +290,7 @@ export class Signer extends Abstractsigner implements TypedDataSigner {
         tx.data,
         toBN(tx.value),
         toBN(gasLimit),
-        toBN(storageLimit)
+        toBN(storageLimit.isNegative() ? 0 : storageLimit)
       );
     } else {
       extrinsic = this.provider.api.tx.evm.call(
@@ -298,7 +298,7 @@ export class Signer extends Abstractsigner implements TypedDataSigner {
         tx.data,
         toBN(tx.value),
         toBN(gasLimit),
-        toBN(storageLimit)
+        toBN(storageLimit.isNegative() ? 0 : storageLimit)
       );
     }
 


### PR DESCRIPTION
Estimate resources can return negative storage used but we can't provide negative limit