### PR TITLE
export evmchai

### DIFF
--- a/bodhi/src/index.ts
+++ b/bodhi/src/index.ts
@@ -3,3 +3,4 @@ export * from './Provider';
 export * from './SigningKey';
 export * from './TestAccountSigningKey';
 export * from './TestProvider';
+export * from './evmChai';


### PR DESCRIPTION
previously `evmchai` is not exported, so we have to import it separatedly
```
import { evmChai } from "@acala-network/bodhi/evmChai";
```

with new `2.x` version, we have to change this usage to 
```
import { evmChai } from "@acala-network/bodhi/lib/evmChai";
```

let's export it from bodhi directly to make more consistent user experience, so user can directly do
```
import { evmChai } from "@acala-network/bodhi";
```
along with other packages.