### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/new-tag-publish.yml
+++ b/.github/workflows/new-tag-publish.yml
@@ -21,10 +21,12 @@ jobs:
       - name: install dependencies
         run: node common/scripts/install-run-rush.js update
 
-      - name: build and publish
+      - name: build all packages
+        run: node common/scripts/install-run-rush.js build
+
+      - name: publish bodhi
         run: |
           cd bodhi
-          yarn build
           yarn publish --access public --verbose
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/evm-subql/package.json
+++ b/evm-subql/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc -b",
+    "build": "yarn codegen && tsc -b",
     "build:watch": "tsc -b",
     "prepack": "rm -rf dist && npm build",
     "test": "jest",


### PR DESCRIPTION
since now bodhi depends on the `eth-providers` package, we need to build all package from root, instead of only building bodhi

also fixed subql build script