### PR TITLE
allow build command to have warning

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -34,6 +34,12 @@
       // Enable "watch mode"
       "watchForChanges": true
     },
+    {
+      "commandKind": "bulk",
+      "name": "build",
+      "summary": "Build all projects that haven't been built, or have changed since they were last built",
+      "allowWarningsInSuccessfulBuild": true
+    },
     // {
     //   /**
     //    * (Required) Determines the type of custom command.


### PR DESCRIPTION
github CI will fail with no-zero exit code, so we need to tell rush to not throw non-zero code for warnings