### PR TITLE
Added Mandala node to docker-compose files for Linux and macOS

### DIFF
--- a/evm-subql/README.md
+++ b/evm-subql/README.md
@@ -2,8 +2,7 @@
 Subquery services that index and query Acala EVM+ transactions.
 
 ## Run
-### prepare
-- first make sure to run an [Acala](https://github.com/AcalaNetwork/Acala) node locally and listen to port 9944. Make sure to feed some EVM transactions to it, for example we can use [these evm examples](https://github.com/AcalaNetwork/evm-examples).
+### Prepare
 
 - install project dependencies
 ```
@@ -17,12 +16,16 @@ yarn
 yarn build
 ```
 
-### run all services with docker
+### Run all services with docker
+This includes a Mandala node within Docker.
+
 for **linux users**, simply do `docker-compose up`, that's all. 
 
 for **mac users**, use a macOS specfic docker compose with `docker-compose -f macos-docker-compose.yml up`.
 
-### run each service seperately
+### Run each service seperately
+- Make sure to run an [Acala](https://github.com/AcalaNetwork/Acala) node locally and listen to port 9944 and make sure to feed some EVM transactions to it, for example we can use [these evm examples](https://github.com/AcalaNetwork/evm-examples).
+
 - 0) install subql lib globally (recommended by the [official doc](https://doc.subquery.network/install/install/#install-subql-cli))
 ```
 npm i -g @subql/node @subql/query

--- a/evm-subql/docker-compose.yml
+++ b/evm-subql/docker-compose.yml
@@ -1,6 +1,22 @@
 version: '3'
 
 services:
+  mandala-node:
+    image: acala/mandala-node:dc8d634b
+    ports:
+      - 9944:9944
+    command:
+      - --dev
+      - -lruntime=debug
+      - -levm=debug
+      - --ws-port=9944
+      - --ws-external=true
+      - --rpc-port=9933
+      - --rpc-external=true
+      - --rpc-cors=all
+      - --rpc-methods=unsafe
+      - --tmp
+
   postgres:
     image: postgres:12-alpine
     ports:

--- a/evm-subql/macos-docker-compose.yml
+++ b/evm-subql/macos-docker-compose.yml
@@ -1,6 +1,22 @@
 version: '3'
 
 services:
+  mandala-node:
+    image: acala/mandala-node:dc8d634b
+    ports:
+      - 9944:9944
+    command:
+      - --dev
+      - -lruntime=debug
+      - -levm=debug
+      - --ws-port=9944
+      - --ws-external=true
+      - --rpc-port=9933
+      - --rpc-external=true
+      - --rpc-cors=all
+      - --rpc-methods=unsafe
+      - --tmp
+
   postgres:
     image: postgres:12-alpine
     ports:
@@ -27,7 +43,7 @@ services:
       - ./:/app
     command:
       - -f=/app
-      - --network-endpoint=ws://host.docker.internal:9944
+      - --network-endpoint=ws://mandala-node:9944
       - --subquery-name=acala-evm
       - --log-level=debug
 


### PR DESCRIPTION
The Mandala node was added to the Docker container, so that the network doesn't have to be run separately. This way we have all of the components dockerized.