### PR TITLE
added eth_gasPrice to eip adaptor

### DIFF
--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -149,9 +149,11 @@ class Eip1193BridgeImpl {
    * Returns the current gas price in wei.
    * @returns GAS PRICE - a hex code of an integer representing the current gas price in wei.
    */
-  // async eth_gasPrice(params: any[]): Promise<any> {
-
-  // }
+  async eth_gasPrice(params: any[]): Promise<string> {
+    validate([], params);
+    const gasPrice = await this.#provider.getGasPrice();
+    return gasPrice.toHexString();
+  }
 
   // async eth_accounts(params: any[]): Promise<any> {
 


### PR DESCRIPTION
## Change
added eth_gasPrice to eip adaptor

## Test
```
GET
{
	"jsonrpc":"2.0",
	"method":"eth_gasPrice",
	"params":[],
	"id":1
}
```
```
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": "0x01"
}
```