### PR TITLE
RPC endpoint tests

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -99,6 +99,7 @@ importers:
       '@rushstack/heft': ~0.41.6
       '@types/bn.js': ~5.1.0
       '@types/jest': ~27.0.1
+      axios: ~0.24.0
       bn.js: 4.12.0
       eslint: ~7.32.0
       ethers: ~5.4.0
@@ -123,6 +124,7 @@ importers:
       '@polkadot/types': 6.4.2
       '@polkadot/util': 7.5.1
       '@polkadot/util-crypto': 7.5.1
+      axios: 0.24.0
       bn.js: 4.12.0
       ethers: 5.4.7
       graphql: 16.0.1
@@ -164,6 +166,7 @@ importers:
       '@types/node': ~16.10.1
       '@types/node-ipc': ~9.1.5
       '@types/ws': ~8.2.0
+      axios: ~0.24.0
       body-parser: ~1.19.0
       connect: ~3.7.0
       cors: ~2.8.5
@@ -194,6 +197,7 @@ importers:
       '@polkadot/types': 6.4.2
       '@polkadot/util': 7.5.1
       '@polkadot/util-crypto': 7.5.1
+      axios: 0.24.0
       body-parser: 1.19.0
       connect: 3.7.0
       cors: 2.8.5
@@ -3172,6 +3176,14 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /axios/0.24.0:
+    resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
+    dependencies:
+      follow-redirects: 1.14.5
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /babel-jest/27.3.1_@babel+core@7.15.8:
     resolution: {integrity: sha512-SjIF8hh/ir0peae2D6S6ZKRhUy7q/DnpH7k/V6fT4Bgs/LXXUztOpX4G2tCgq8mLo5HA9mN6NmlFMeYtKmIsTQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4638,6 +4650,16 @@ packages:
   /flatted/3.2.2:
     resolution: {integrity: sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==}
     dev: true
+
+  /follow-redirects/1.14.5:
+    resolution: {integrity: sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
 
   /form-data/3.0.1:
     resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}

--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "author": "Acala Developers <hello@acala.network>",
   "scripts": {
-    "build": "heft build --clean",
+    "build": "yarn gql:typegen && heft build --clean",
     "build:watch": "heft build",
     "lint": "tsc --noEmit && eslint \"**/*.ts\"",
     "test": "jest --forceExit --coverage --verbose",

--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "author": "Acala Developers <hello@acala.network>",
   "scripts": {
-    "build": "yarn gql:typegen && heft build --clean",
+    "build": "heft build --clean",
     "build:watch": "heft build",
     "lint": "tsc --noEmit && eslint \"**/*.ts\"",
     "test": "jest --forceExit --coverage --verbose",

--- a/eth-rpc-adapter/jest.config.js
+++ b/eth-rpc-adapter/jest.config.js
@@ -11,6 +11,9 @@ module.exports = {
   transform: {
     '^.+\\.(t|j)s$': 'ts-jest'
   },
-  testPathIgnorePatterns: ['/dist', '/lib'],
+  testPathIgnorePatterns: [
+    // TODO: remove these when testing locally, or after we have a public testnet WS endpoint
+    'queries.test.ts'
+  ],
   transformIgnorePatterns: ['@polkadot+util-crypto.*/node_modules/@polkadot/util-crypto']
 };

--- a/eth-rpc-adapter/jest.config.js
+++ b/eth-rpc-adapter/jest.config.js
@@ -12,8 +12,10 @@ module.exports = {
     '^.+\\.(t|j)s$': 'ts-jest'
   },
   testPathIgnorePatterns: [
+    '/dist',
+    '/lib',
     // TODO: remove these when testing locally, or after we have a public testnet WS endpoint
-    'queries.test.ts'
+    'endpoint.test.ts'
   ],
   transformIgnorePatterns: ['@polkadot+util-crypto.*/node_modules/@polkadot/util-crypto']
 };

--- a/eth-rpc-adapter/package.json
+++ b/eth-rpc-adapter/package.json
@@ -34,7 +34,8 @@
     "pino": "~7.0.0-rc.3",
     "ws": "~8.2.2",
     "@acala-network/types": "~3.0.1",
-    "@ethersproject/logger": "~5.4.0"
+    "@ethersproject/logger": "~5.4.0",
+    "axios": "~0.24.0"
   },
   "devDependencies": {
     "@types/body-parser": "~1.19.1",

--- a/eth-rpc-adapter/src/__tests__/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/endpoint.test.ts
@@ -1,0 +1,250 @@
+import axios from 'axios';
+import { getAllTxReceipts, getAllLogs } from '@acala-network/eth-providers/lib/utils';
+import { Log } from '@ethersproject/abstract-provider';
+
+const RPC_URL = 'http://localhost:8545';
+const rpcGet =
+  (method: string) =>
+  (params: any): any =>
+    axios.get(RPC_URL, {
+      data: {
+        id: 0,
+        jsonrpc: '2.0',
+        method,
+        params
+      }
+    });
+
+export const logsEq = (a: Log[], b: Log[]): boolean =>
+  a.length === b.length &&
+  a.every(({ transactionHash: t0, logIndex: l0 }) =>
+    b.find(({ transactionHash: t1, logIndex: l1 }) => t0 === t1 && l0 === l1)
+  );
+
+describe('eth_getTransactionReceipt', () => {
+  const eth_getTransactionReceipt = rpcGet('eth_getTransactionReceipt');
+
+  it('returns correct result when hash exist', async () => {
+    const allTxReceipts = await getAllTxReceipts();
+
+    // test first one
+    let txR = allTxReceipts[0];
+    let res = await eth_getTransactionReceipt([txR.transactionHash]);
+    expect(res.status).toEqual(200);
+    expect(res.data.result.transactionHash).toEqual(txR.transactionHash);
+
+    // test last one
+    txR = allTxReceipts[allTxReceipts.length - 1];
+    res = await eth_getTransactionReceipt([txR.transactionHash]);
+    expect(res.status).toEqual(200);
+    expect(res.data.result.transactionHash).toEqual(txR.transactionHash);
+
+    // test middle one
+    txR = allTxReceipts[Math.floor(allTxReceipts.length / 2)];
+    res = await eth_getTransactionReceipt([txR.transactionHash]);
+    expect(res.status).toEqual(200);
+    expect(res.data.result.transactionHash).toEqual(txR.transactionHash);
+  });
+
+  it('return correct error code and messge', async () => {
+    let res;
+
+    /* ---------- invalid hex address ---------- */
+    res = await eth_getTransactionReceipt(['0x000']);
+    expect(res.status).toEqual(200);
+    expect(res.data.error.code).toEqual(-32602);
+    expect(res.data.error.message).toContain('invalid argument');
+
+    /* ---------- hash not found ---------- */
+    res = await eth_getTransactionReceipt(['0x7ae069634d1154c0299f7fe1d473cf3d6f06cd9b57182d5319eede35a3a4d776']);
+    expect(res.status).toEqual(200);
+    expect(res.data.error.code).toEqual(6969);
+    expect(res.data.error.message).toContain('transaction hash not found');
+  });
+});
+
+describe('eth_getLogs', () => {
+  const eth_getLogs = rpcGet('eth_getLogs');
+
+  describe('when no filter', () => {
+    it('returns all logs', async () => {
+      const allLogs = await getAllLogs();
+      const res = await eth_getLogs([{}]);
+
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, allLogs)).toBe(true);
+    });
+  });
+
+  describe('filter by address', () => {
+    it('returns correct logs', async () => {
+      const allLogs = await getAllLogs();
+      const log1 = allLogs[0];
+      const log2 = allLogs[allLogs.length - 1];
+      const log3 = allLogs[Math.floor(allLogs.length / 2)];
+      let res;
+      let expectedLogs;
+
+      /* ---------- single address ---------- */
+      res = await eth_getLogs([{ address: log1.address }]);
+      expectedLogs = allLogs.filter((l) => l.address === log1.address);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+
+      res = await eth_getLogs([{ address: log2.address }]);
+      expectedLogs = allLogs.filter((l) => l.address === log2.address);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+
+      res = await eth_getLogs([{ address: log3.address }]);
+      expectedLogs = allLogs.filter((l) => l.address === log3.address);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+
+      /* ---------- multiple address ---------- */
+      // TODO: interestingly, current Filter type says address can only be string
+      // can support string[] filter if we needed in the future
+    });
+  });
+
+  describe('filter by block number', () => {
+    it('returns correct logs', async () => {
+      const BIG_NUMBER = 88888888;
+      const allLogs = await getAllLogs();
+      let res;
+      let expectedLogs;
+
+      /* ---------- should return all logs ---------- */
+      res = await eth_getLogs([{ fromBlock: 0 }]);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, allLogs)).toBe(true);
+
+      res = await eth_getLogs([{ toBlock: BIG_NUMBER }]);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, allLogs)).toBe(true);
+
+      res = await eth_getLogs([{ fromBlock: 0, toBlock: BIG_NUMBER }]);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, allLogs)).toBe(true);
+
+      /* ---------- should return no logs ---------- */
+      res = await eth_getLogs([{ fromBlock: 99999 }]);
+      expect(res.status).toEqual(200);
+      expect(res.data.result).toEqual([]);
+
+      res = await eth_getLogs([{ toBlock: -1 }]);
+      expect(res.status).toEqual(200);
+      expect(res.data.result).toEqual([]);
+
+      /* ---------- should return partial logs ---------- */
+      const from = 16;
+      const to = 50;
+      res = await eth_getLogs([{ fromBlock: from }]);
+      expect(res.status).toEqual(200);
+      expectedLogs = allLogs.filter((l) => l.blockNumber >= from);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+
+      res = await eth_getLogs([{ toBlock: to }]);
+      expect(res.status).toEqual(200);
+      expectedLogs = allLogs.filter((l) => l.blockNumber <= to);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+
+      res = await eth_getLogs([{ fromBlock: from, toBlock: to }]);
+      expect(res.status).toEqual(200);
+      expectedLogs = allLogs.filter((l) => l.blockNumber >= from && l.blockNumber <= to);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+    });
+  });
+
+  describe('filter by block tag', () => {
+    it('returns correct logs for valid tag', async () => {
+      const allLogs = await getAllLogs();
+      let res;
+      let expectedLogs;
+
+      /* ---------- should return all logs ---------- */
+      res = await eth_getLogs([{ fromBlock: 'earliest' }]);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, allLogs)).toBe(true);
+
+      res = await eth_getLogs([{ toBlock: 'latest' }]);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, allLogs)).toBe(true);
+
+      res = await eth_getLogs([{ fromBlock: 'earliest', toBlock: 'latest' }]);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, allLogs)).toBe(true);
+
+      /* ---------- should return no logs ---------- */
+      res = await eth_getLogs([{ fromBlock: 'latest', toBlock: 'earliest' }]);
+      expect(res.data.result).toEqual([]);
+
+      res = await eth_getLogs([{ fromBlock: 'latest', toBlock: 5 }]);
+      expect(res.data.result).toEqual([]);
+
+      res = await eth_getLogs([{ fromBlock: 8, toBlock: 'earliest' }]);
+      expect(res.data.result).toEqual([]);
+
+      /* ---------- should return some logs ---------- */
+      const from = 17;
+      const to = 50;
+      res = await eth_getLogs([{ fromBlock: from, toBlock: 'latest' }]);
+      expect(res.status).toEqual(200);
+      expectedLogs = allLogs.filter((l) => l.blockNumber >= from);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+
+      res = await eth_getLogs([{ fromBlock: 'earliest', toBlock: to }]);
+      expect(res.status).toEqual(200);
+      expectedLogs = allLogs.filter((l) => l.blockNumber <= to);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+
+      res = await eth_getLogs([{ fromBlock: from, toBlock: to }]);
+      expect(res.status).toEqual(200);
+      expectedLogs = allLogs.filter((l) => l.blockNumber >= from && l.blockNumber <= to);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+    });
+
+    it('returns correct error code and messge for invalid tag', async () => {
+      const res = await eth_getLogs([{ fromBlock: 'polkadot' }]);
+      expect(res.status).toEqual(200);
+      expect(res.data.error.code).toEqual(-32602);
+      expect(res.data.error.message).toContain("blocktag should be number | 'latest' | 'earliest'");
+    });
+  });
+
+  describe('filter by topics', () => {
+    it('returns correct logs', async () => {
+      const allLogs = await getAllLogs();
+      const log1 = allLogs[0];
+      const log2 = allLogs[allLogs.length - 1];
+      const log3 = allLogs[Math.floor(allLogs.length / 2)];
+      let res;
+      let expectedLogs;
+
+      /* ---------- should return all logs ---------- */
+      res = await eth_getLogs([{ topics: [] }]);
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, allLogs)).toBe(true);
+
+      /* ---------- should return no logs ---------- */
+      res = await eth_getLogs([{ topics: ['XXX'] }]);
+      expect(res.data.result).toEqual([]);
+
+      /* ---------- should return some logs ---------- */
+      res = await eth_getLogs([{ topics: log1.topics }]);
+      expectedLogs = allLogs.filter((l) => l.topics.every((t) => log1.topics.includes(t)));
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+
+      res = await eth_getLogs([{ topics: log2.topics }]);
+      expectedLogs = allLogs.filter((l) => l.topics.every((t) => log2.topics.includes(t)));
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+
+      res = await eth_getLogs([{ topics: log3.topics }]);
+      expectedLogs = allLogs.filter((l) => l.topics.every((t) => log3.topics.includes(t)));
+      expect(res.status).toEqual(200);
+      expect(logsEq(res.data.result, expectedLogs)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Change
previously we only have some unit tests for subquery helper functions, in order to be more confident about the actual RPC endpoint, I added some endpoint tests for `getLogs` and `getTransactionReceipt`

## Test
all test cases passed locally with some simple EVM event