### PR TITLE
implement eth_getTransaction

### DIFF
--- a/bodhi/.eslintrc.js
+++ b/bodhi/.eslintrc.js
@@ -3,5 +3,16 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
   extends: ['@rushstack/eslint-config/profile/node-trusted-tool'], // <---- put your profile string here
-  parserOptions: { tsconfigRootDir: __dirname }
+  parserOptions: { tsconfigRootDir: __dirname },
+  rules: {
+    eqeqeq: 1,
+    '@typescript-eslint/no-use-before-define': 1,
+
+    '@typescript-eslint/explicit-member-accessibility': 0,
+    '@rushstack/typedef-var': 0,
+    '@typescript-eslint/naming-convention': 0,
+    '@typescript-eslint/no-explicit-any': 0, // any is sometimes unavoidable
+    '@typescript-eslint/consistent-type-definitions': 0, // can use Type and Interface
+    '@rushstack/no-new-null': 0 // can use null as return type
+  }
 };

--- a/eth-providers/.eslintrc.js
+++ b/eth-providers/.eslintrc.js
@@ -5,10 +5,14 @@ module.exports = {
   extends: ['@rushstack/eslint-config/profile/node-trusted-tool'], // <---- put your profile string here
   parserOptions: { tsconfigRootDir: __dirname },
   rules: {
-    eqeqeq: 'warn',
-    '@typescript-eslint/explicit-member-accessibility': 'off',
-    '@rushstack/typedef-var': 'off',
-    '@typescript-eslint/naming-convention': 'off',
-    '@typescript-eslint/no-use-before-define': 'warn'
+    eqeqeq: 1,
+    '@typescript-eslint/no-use-before-define': 1,
+
+    '@typescript-eslint/explicit-member-accessibility': 0,
+    '@rushstack/typedef-var': 0,
+    '@typescript-eslint/naming-convention': 0,
+    '@typescript-eslint/no-explicit-any': 0, // any is sometimes unavoidable
+    '@typescript-eslint/consistent-type-definitions': 0, // can use Type and Interface
+    '@rushstack/no-new-null': 0 // can use null as return type
   }
 };

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -804,7 +804,7 @@ export abstract class BaseProvider extends AbstractProvider {
       return logger.throwError(`extrinsic not found from hash`, Logger.errors.UNKNOWN_ERROR, { transactionHash });
     }
 
-    const { args } = JSON.parse(extrinsic as any).method;
+    const { args } = extrinsic.method.toJSON();
     const input = (args as any).input ?? '';
     const value = (args as any).value ?? 0;
 

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -19,7 +19,7 @@ import { Deferrable, defineReadOnly, resolveProperties } from '@ethersproject/pr
 import { accessListify, parse, Transaction } from '@ethersproject/transactions';
 import { ApiPromise } from '@polkadot/api';
 import { createHeaderExtended } from '@polkadot/api-derive';
-import type { Option, Vec } from '@polkadot/types';
+import type { GenericExtrinsic, Option, Vec } from '@polkadot/types';
 import type { AccountId, DispatchInfo, EvmLog } from '@polkadot/types/interfaces';
 import type BN from 'bn.js';
 import { BigNumber, BigNumberish } from 'ethers';
@@ -91,6 +91,22 @@ export interface CallRequest {
   value?: BigNumberish;
   data?: string;
 }
+
+export interface TX {
+  from: string;
+  to: string | null;
+  hash: string;
+  blockHash: string;
+  nonce: number;
+  blockNumber: number;
+  transactionIndex: number;
+  value: BigNumberish;
+  gasPrice: BigNumber;
+  gas: BigNumberish;
+  input: string;
+}
+
+export const DEFAULT_CONFIRMATIONS = 1;
 
 export abstract class BaseProvider extends AbstractProvider {
   readonly _api?: ApiPromise;
@@ -689,6 +705,13 @@ export abstract class BaseProvider extends AbstractProvider {
     return await resolveProperties(tx);
   };
 
+  _getExtrinsicByHashAtBlock = async (txHash: string, blockHash: string): Promise<GenericExtrinsic | undefined> => {
+    const block = await this.api.rpc.chain.getBlock(blockHash.toLowerCase());
+
+    const _txHash = txHash.toLowerCase();
+    return block.block.extrinsics.find((e) => e.hash.toHex() === _txHash);
+  };
+
   // @TODO Testing
   getTransactionReceiptAtBlock = async (txHash: string, blockHash: string): Promise<TransactionReceipt> => {
     txHash = txHash.toLowerCase();
@@ -744,7 +767,7 @@ export abstract class BaseProvider extends AbstractProvider {
 
     // to and contractAddress may be undefined
     return {
-      confirmations: 1,
+      confirmations: DEFAULT_CONFIRMATIONS,
       ...transactionInfo,
       ...partialTransactionReceipt,
       logs: partialTransactionReceipt.logs.map((log) => ({
@@ -766,6 +789,36 @@ export abstract class BaseProvider extends AbstractProvider {
 
   // Queries
   getTransaction = (transactionHash: string): Promise<TransactionResponse> => throwNotImplemented('getTransaction');
+
+  getTransactionByHash = async (transactionHash: string): Promise<TX> => {
+    const tx = await getTxReceiptByHash(transactionHash);
+
+    if (!tx) {
+      return logger.throwError(`transaction hash not found`, Logger.errors.UNKNOWN_ERROR, { transactionHash });
+    }
+
+    const nonce = await this.getEvmTransactionCount(tx.from, tx.blockHash);
+    const extrinsic = await this._getExtrinsicByHashAtBlock(transactionHash, tx.blockHash);
+
+    const { args } = JSON.parse(extrinsic! as any).method;
+    const input = (args as any).input ?? '';
+    const value = (args as any).value ?? 0;
+
+    return {
+      from: tx.from,
+      to: tx.to || null,
+      hash: tx.transactionHash,
+      blockHash: tx.blockHash,
+      nonce,
+      blockNumber: tx.blockNumber,
+      transactionIndex: tx.transactionIndex,
+      value,
+      gasPrice: GAS_PRICE,
+      gas: tx.gasUsed,
+      input
+    };
+  };
+
   getTransactionReceipt = async (transactionHash: string): Promise<TransactionReceipt> => {
     const tx = await getTxReceiptByHash(transactionHash);
 
@@ -773,8 +826,8 @@ export abstract class BaseProvider extends AbstractProvider {
       return logger.throwError(`transaction hash not found`, Logger.errors.UNKNOWN_ERROR, { transactionHash });
     }
 
-    // TODO: correct values of these?
-    const confirmations = 1;
+    // NOTE: these two values are not indexed yet from evm-subql
+    // we can index them if needed in the future
     const byzantium = false;
     const defaultAddress = '0x';
 
@@ -793,7 +846,7 @@ export abstract class BaseProvider extends AbstractProvider {
       type: tx.type,
       status: tx.status,
       effectiveGasPrice: EFFECTIVE_GAS_PRICE,
-      confirmations,
+      confirmations: DEFAULT_CONFIRMATIONS,
       byzantium
     };
   };

--- a/eth-rpc-adapter/.eslintrc.js
+++ b/eth-rpc-adapter/.eslintrc.js
@@ -5,7 +5,14 @@ module.exports = {
   extends: ['@rushstack/eslint-config/profile/node-trusted-tool'], // <---- put your profile string here
   parserOptions: { tsconfigRootDir: __dirname },
   rules: {
-    eqeqeq: 'warn',
-    '@typescript-eslint/no-use-before-define': 'warn'
+    eqeqeq: 1,
+    '@typescript-eslint/no-use-before-define': 1,
+
+    '@typescript-eslint/explicit-member-accessibility': 0,
+    '@rushstack/typedef-var': 0,
+    '@typescript-eslint/naming-convention': 0,
+    '@typescript-eslint/no-explicit-any': 0, // any is sometimes unavoidable
+    '@typescript-eslint/consistent-type-definitions': 0, // can use Type and Interface
+    '@rushstack/no-new-null': 0 // can use null as return type
   }
 };

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -1,7 +1,7 @@
 import { hexValue } from '@ethersproject/bytes';
 import { TransactionReceipt, Log } from '@ethersproject/abstract-provider';
 import EventEmitter from 'events';
-import { EvmRpcProvider } from '@acala-network/eth-providers';
+import { EvmRpcProvider, TX } from '@acala-network/eth-providers';
 import { hexlifyRpcResult } from './utils';
 import { MethodNotFound } from './errors';
 import { validate } from './validate';
@@ -215,9 +215,10 @@ class Eip1193BridgeImpl {
     return val.toHexString();
   }
 
-  // async eth_getTransactionByHash(params: any[]): Promise<any> {
-
-  // }
+  async eth_getTransactionByHash(params: any[]): Promise<TX> {
+    validate([{ type: 'blockHash' }], params);
+    return hexlifyRpcResult(await this.#provider.getTransactionByHash(params[0]));
+  }
 
   async eth_getTransactionReceipt(params: any[]): Promise<TransactionReceipt> {
     validate([{ type: 'blockHash' }], params);

--- a/eth-rpc-adapter/tsconfig.json
+++ b/eth-rpc-adapter/tsconfig.json
@@ -23,5 +23,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules/*", "**/e2e/*", "**/*.(test|spec).ts"]
+  "exclude": ["node_modules/*", "**/e2e/*", "**/*.(test|spec).ts", "**/__tests__"]
 }


### PR DESCRIPTION
## Change
- implemented `eth_getTransaction` method. Note that I created a new method `getTransactionByHash` instead of using the `getTransaction` from base provider, since there are a lot of type mismatch.
- updated eslint rules to ignore some common warning (in the future we will fix other lint errors and try to make linting pass)

## Test
added some unit tests for the `eth_getTransaction` RPC endpoint