### PR TITLE
able to deploy hello world contract

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -91,32 +91,30 @@ export interface CallRequest {
   data?: string;
 }
 
-export interface TX {
+export interface partialTX {
   from: string;
   to: string | null;
-  hash: string;
   blockHash: string;
-  nonce: number;
   blockNumber: number;
   transactionIndex: number;
+}
+
+export interface TX extends partialTX {
+  hash: string;
+  nonce: number;
   value: BigNumberish;
   gasPrice: BigNumber;
   gas: BigNumberish;
   input: string;
 }
 
-export interface TXReceipt {
-  from: string;
-  to: string | null;
+export interface TXReceipt extends partialTX {
   contractAddress: string | null;
-  transactionIndex: number;
   root?: string;
   gasUsed: BigNumber;
   logsBloom: string;
-  blockHash: string;
   transactionHash: string;
   logs: Array<Log>;
-  blockNumber: number;
   confirmations: number;
   cumulativeGasUsed: BigNumber;
   effectiveGasPrice: BigNumber;
@@ -804,7 +802,8 @@ export abstract class BaseProvider extends AbstractProvider {
    */
 
   // Queries
-  getTransaction = (transactionHash: string): Promise<TransactionResponse> => throwNotImplemented('getTransaction');
+  getTransaction = (transactionHash: string): Promise<TransactionResponse> =>
+    throwNotImplemented('getTransaction (deprecated: please use getTransactionByHash)');
 
   getTransactionByHash = async (transactionHash: string): Promise<TX> => {
     const tx = await getTxReceiptByHash(transactionHash);
@@ -840,7 +839,7 @@ export abstract class BaseProvider extends AbstractProvider {
   };
 
   getTransactionReceipt = async (transactionHash: string): Promise<TransactionReceipt> =>
-    throwNotImplemented('getTransactionReceipt (deprecated: use getTXReceiptByHash)');
+    throwNotImplemented('getTransactionReceipt (deprecated: please use getTXReceiptByHash)');
 
   getTXReceiptByHash = async (transactionHash: string): Promise<TXReceipt> => {
     const tx = await getTxReceiptByHash(transactionHash);

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -105,6 +105,25 @@ export interface TX {
   input: string;
 }
 
+export interface TXReceipt {
+  from: string;
+  to: string | null;
+  contractAddress: string | null;
+  transactionIndex: number;
+  root?: string;
+  gasUsed: BigNumber;
+  logsBloom: string;
+  blockHash: string;
+  transactionHash: string;
+  logs: Array<Log>;
+  blockNumber: number;
+  confirmations: number;
+  cumulativeGasUsed: BigNumber;
+  effectiveGasPrice: BigNumber;
+  type: number;
+  status?: number;
+}
+
 export const DEFAULT_CONFIRMATIONS = 1;
 
 export abstract class BaseProvider extends AbstractProvider {
@@ -820,22 +839,20 @@ export abstract class BaseProvider extends AbstractProvider {
     };
   };
 
-  getTransactionReceipt = async (transactionHash: string): Promise<TransactionReceipt> => {
+  getTransactionReceipt = async (transactionHash: string): Promise<TransactionReceipt> =>
+    throwNotImplemented('getTransactionReceipt (deprecated: use getTXReceiptByHash)');
+
+  getTXReceiptByHash = async (transactionHash: string): Promise<TXReceipt> => {
     const tx = await getTxReceiptByHash(transactionHash);
 
     if (!tx) {
       return logger.throwError(`transaction hash not found`, Logger.errors.UNKNOWN_ERROR, { transactionHash });
     }
 
-    // NOTE: these two values are not indexed yet from evm-subql
-    // we can index them if needed in the future
-    const byzantium = false;
-    const defaultAddress = '0x';
-
     return {
-      to: tx.to || defaultAddress,
+      to: tx.to || null,
       from: tx.from,
-      contractAddress: tx.contractAddress || defaultAddress,
+      contractAddress: tx.contractAddress || null,
       transactionIndex: tx.transactionIndex,
       gasUsed: tx.gasUsed,
       logsBloom: tx.logsBloom,
@@ -847,8 +864,7 @@ export abstract class BaseProvider extends AbstractProvider {
       type: tx.type,
       status: tx.status,
       effectiveGasPrice: EFFECTIVE_GAS_PRICE,
-      confirmations: (await this._getBlockNumberFromTag('latest')) - tx.blockNumber,
-      byzantium
+      confirmations: (await this._getBlockNumberFromTag('latest')) - tx.blockNumber
     };
   };
 

--- a/eth-rpc-adapter/package.json
+++ b/eth-rpc-adapter/package.json
@@ -12,7 +12,7 @@
     "test": "mocha **/*.test.ts --ignore **/e2e/**",
     "test:dev": "mocha **/*.test.ts --watch --watch-files **/*.test.ts",
     "start": "ts-node src/index",
-    "dev": "nodemon --watch \"src/**,node_modules/**\" --ext \"ts,json\" --ignore \"src/**/*.spec.ts\" --exec \"ts-node src/index.ts\" | pino-pretty"
+    "dev": "nodemon --watch \"*\" --ext \"js,ts,json\" --ignore \"src/**/*.spec.ts\" --exec \"ts-node src/index.ts\" | pino-pretty"
   },
   "dependencies": {
     "@acala-network/eth-providers": "workspace:*",

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -256,7 +256,7 @@ class Eip1193BridgeImpl {
   async eth_getTransactionByHash(params: any[]): Promise<TX> {
     validate([{ type: 'blockHash' }], params);
 
-    const res = await this._runWithRetries(this.#provider.getTransactionByHash, params);
+    const res = await this._runWithRetries<TX>(this.#provider.getTransactionByHash, params);
     return hexlifyRpcResult(res);
   }
 

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -256,7 +256,7 @@ class Eip1193BridgeImpl {
   async eth_getTransactionByHash(params: any[]): Promise<TX> {
     validate([{ type: 'blockHash' }], params);
 
-    const res = await this._runWithRetries(this.#provider.getTransactionByHash, [params[0]]);
+    const res = await this._runWithRetries(this.#provider.getTransactionByHash, params);
     return hexlifyRpcResult(res);
   }
 
@@ -268,7 +268,7 @@ class Eip1193BridgeImpl {
   async eth_getTransactionReceipt(params: any[]): Promise<TransactionReceipt> {
     validate([{ type: 'blockHash' }], params);
 
-    const res = await this._runWithRetries<TXReceipt>(this.#provider.getTXReceiptByHash, [params[0]]);
+    const res = await this._runWithRetries<TXReceipt>(this.#provider.getTXReceiptByHash, params);
     return hexlifyRpcResult(res);
   }
 

--- a/eth-rpc-adapter/src/utils/index.ts
+++ b/eth-rpc-adapter/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './hexlifyRpcResult';
+export * from './utils';

--- a/eth-rpc-adapter/src/utils/utils.ts
+++ b/eth-rpc-adapter/src/utils/utils.ts
@@ -1,0 +1,1 @@
+export const sleep = async (time: number = 1000): Promise<void> => new Promise((resolve) => setTimeout(resolve, time));


### PR DESCRIPTION
## Change
- added wait and retry logic to getTransaction related methods. Since we can't find/index the tx immediately (need to wait for at least next block as @ntduan mentioned), even with unfinalized block cache, we still need to wait for a bit. 
- changed `getTransactionReceipt` return type to match the actual infura and eth wiki definition, instead of compromising for the (inaccurate) types from `@ethers` project. This will solve https://github.com/AcalaNetwork/bodhi.js/issues/73#issuecomment-970778284

after these two changes, we will be able to deploy the hello world contract by @ThunderDeliverer (I think it is not uploaded anywhere yet? maybe we can integrate it as tests in the future)

## Test
- up to this two lines from hello world work
```ts
        const HelloWorld = await ethers.getContractFactory("HelloWorld");

        const instance = await HelloWorld.deploy();
```
- previous unit tests still pass