### PR TITLE
Unfinalized cache

### DIFF
--- a/eth-providers/src/__tests__/cache.test.ts
+++ b/eth-providers/src/__tests__/cache.test.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import { it } from 'mocha';
+import { UnfinalizedBlockCache } from '../utils/unfinalizedBlockCache';
+
+const randFakeHash = (): string => Math.floor(Math.random() * 66666666).toString(16);
+
+const mockBlock = (): string[] => Array.from({ length: Math.floor(Math.random() * 5) }, () => randFakeHash());
+
+const mockChain = (blocksCount: number = 50): string[][] => Array.from({ length: blocksCount }, () => mockBlock());
+
+describe('UnfinalizedBlockCache', () => {
+  const cache = new UnfinalizedBlockCache();
+  const TOTAL_BLOCKS = 80;
+  const chain = mockChain(TOTAL_BLOCKS);
+
+  describe('initialization', () => {
+    it('initialize two empty map', () => {
+      expect(cache.blockTxHashes).to.deep.equal({});
+      expect(cache.allTxHashes).to.deep.equal({});
+    });
+  });
+
+  describe('add block', () => {
+    it('correctly find cached transactions', () => {
+      chain.forEach((transactions, idx) => cache.addTxsAtBlock(idx, transactions));
+
+      for (let blockNumber = 0; blockNumber < TOTAL_BLOCKS; blockNumber++) {
+        for (const curTx of chain[blockNumber]) {
+          expect(cache.getBlockNumber(curTx)).to.equal(blockNumber);
+        }
+      }
+    });
+  });
+
+  describe('update finalized block', () => {
+    it('correctly remove tx from finalized block', () => {
+      chain.forEach((transactions, idx) => cache.addTxsAtBlock(idx, transactions));
+
+      for (let blockNumber = 0; blockNumber < TOTAL_BLOCKS; blockNumber++) {
+        const curBlock = chain[blockNumber];
+        cache.updateFinalizedHead(blockNumber);
+
+        // these tx from finalized block should be removed
+        for (const curTx of curBlock) {
+          expect(cache.getBlockNumber(curTx)).to.equal(undefined);
+        }
+
+        // these tx from unfinalized block should still be there
+        // ufbn => unfinalizeBlockNumber
+        for (let ufbn = blockNumber + 1; ufbn < TOTAL_BLOCKS; ufbn++) {
+          for (const tx of chain[ufbn]) {
+            expect(cache.getBlockNumber(tx)).to.equal(ufbn);
+          }
+        }
+      }
+    });
+  });
+});

--- a/eth-providers/src/__tests__/cache.test.ts
+++ b/eth-providers/src/__tests__/cache.test.ts
@@ -38,7 +38,7 @@ describe('UnfinalizedBlockCache', () => {
 
       for (let blockNumber = 0; blockNumber < TOTAL_BLOCKS; blockNumber++) {
         const curBlock = chain[blockNumber];
-        cache.updateFinalizedHead(blockNumber);
+        cache.removeTxsAtBlock(blockNumber);
 
         // these tx from finalized block should be removed
         for (const curTx of curBlock) {

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -20,7 +20,7 @@ import { accessListify, parse, Transaction } from '@ethersproject/transactions';
 import { ApiPromise } from '@polkadot/api';
 import { createHeaderExtended } from '@polkadot/api-derive';
 import type { GenericExtrinsic, Option } from '@polkadot/types';
-import type { AccountId } from '@polkadot/types/interfaces';
+import type { AccountId, Header } from '@polkadot/types/interfaces';
 import type BN from 'bn.js';
 import { BigNumber, BigNumberish } from 'ethers';
 import {
@@ -834,6 +834,16 @@ export abstract class BaseProvider extends AbstractProvider {
     throwNotImplemented('getTransaction (deprecated: please use getTransactionByHash)');
 
   getTransactionByHash = async (transactionHash: string): Promise<TX> => {
+    const sub1 = await this.api.rpc.chain.subscribeNewHeads((header: Header) =>
+      console.log('new block: ', header.number.toNumber())
+    );
+    const sub2 = await this.api.rpc.chain.subscribeFinalizedHeads((header: Header) =>
+      console.log('new finalized block: ', header.number.toNumber())
+    );
+    const sub3 = await this.api.rpc.chain.subscribeAllHeads((header: Header) =>
+      console.log('new all heads: ', header.number.toNumber())
+    );
+
     const tx = await getTxReceiptByHash(transactionHash);
 
     if (!tx) {

--- a/eth-providers/src/rpc-provider.ts
+++ b/eth-providers/src/rpc-provider.ts
@@ -8,6 +8,7 @@ export class EvmRpcProvider extends BaseProvider {
     super();
     const api = createApi(endpoint);
     this.setApi(api);
+    this.subscribe() as unknown as void;
   }
 
   sendTransaction = (signedTransaction: string | Promise<string>): Promise<TransactionResponse> =>

--- a/eth-providers/src/rpc-provider.ts
+++ b/eth-providers/src/rpc-provider.ts
@@ -8,7 +8,7 @@ export class EvmRpcProvider extends BaseProvider {
     super();
     const api = createApi(endpoint);
     this.setApi(api);
-    this.subscribe() as unknown as void;
+    this.startCache() as unknown as void;
   }
 
   sendTransaction = (signedTransaction: string | Promise<string>): Promise<TransactionResponse> =>

--- a/eth-providers/src/utils/unfinalizedBlockCache.ts
+++ b/eth-providers/src/utils/unfinalizedBlockCache.ts
@@ -1,0 +1,50 @@
+import { TransactionReceipt } from 'src';
+
+interface HashToBlockMap {
+  [hash: string]: number;
+}
+
+interface BlockToHashesMap {
+  [block: string]: string[];
+}
+
+export class UnfinalizedBlockCache {
+  blockTxHashes: BlockToHashesMap = {};
+  allTxHashes: HashToBlockMap = {};
+
+  addTxsAtBlock(blockNumber: number, txHashes: string[]): void {
+    txHashes.forEach((h) => (this.allTxHashes[h] = blockNumber));
+    this.blockTxHashes[blockNumber] = txHashes;
+  }
+
+  updateFinalizedHead(blockNumber: number): void {
+    this.blockTxHashes[blockNumber].forEach((h) => delete this.allTxHashes[h]);
+    delete this.blockTxHashes[blockNumber];
+  }
+
+  getBlockNumber(hash: string): number | undefined {
+    return this.allTxHashes[hash];
+  }
+}
+
+// const createUnfinalizedBlockCache = (api: ApiPromise): UnfinalizedBlockCache => {
+//   const cache = new UnfinalizedBlockCache()
+
+//   this.api.rpc.chain.subscribeNewHeads(header => {
+//     const txHashes = getTxHashes(header);
+//     cache.addBlock(header.blockNumber, txHashes)
+//   });
+
+//   this.api.rpc.chain.subscribeFinalizedHeads(header => {
+//     cache.updateFinalizedHead(header.blockNumber)
+//   });
+
+//   return cache;
+// }
+
+// const cache = createUnfinalizedBlockCache();
+
+// const getTxFromCache = (txHash): TransactionReceipt | null => {
+//   const blockNumber = cache.getBlockNumber(txHash);
+//   return blockNumber ? getTransactionReceiptAtBlock(txHash, blockNumber) : null;
+// }

--- a/eth-providers/src/utils/unfinalizedBlockCache.ts
+++ b/eth-providers/src/utils/unfinalizedBlockCache.ts
@@ -15,7 +15,7 @@ export class UnfinalizedBlockCache {
     this.blockTxHashes[blockNumber] = txHashes;
   }
 
-  updateFinalizedHead(blockNumber: number): void {
+  removeTxsAtBlock(blockNumber: number): void {
     this.blockTxHashes[blockNumber]?.forEach((h) => delete this.allTxHashes[h]);
     delete this.blockTxHashes[blockNumber];
   }

--- a/eth-providers/src/utils/unfinalizedBlockCache.ts
+++ b/eth-providers/src/utils/unfinalizedBlockCache.ts
@@ -1,5 +1,3 @@
-import { TransactionReceipt } from 'src';
-
 interface HashToBlockMap {
   [hash: string]: number;
 }
@@ -18,7 +16,7 @@ export class UnfinalizedBlockCache {
   }
 
   updateFinalizedHead(blockNumber: number): void {
-    this.blockTxHashes[blockNumber].forEach((h) => delete this.allTxHashes[h]);
+    this.blockTxHashes[blockNumber]?.forEach((h) => delete this.allTxHashes[h]);
     delete this.blockTxHashes[blockNumber];
   }
 
@@ -26,25 +24,3 @@ export class UnfinalizedBlockCache {
     return this.allTxHashes[hash];
   }
 }
-
-// const createUnfinalizedBlockCache = (api: ApiPromise): UnfinalizedBlockCache => {
-//   const cache = new UnfinalizedBlockCache()
-
-//   this.api.rpc.chain.subscribeNewHeads(header => {
-//     const txHashes = getTxHashes(header);
-//     cache.addBlock(header.blockNumber, txHashes)
-//   });
-
-//   this.api.rpc.chain.subscribeFinalizedHeads(header => {
-//     cache.updateFinalizedHead(header.blockNumber)
-//   });
-
-//   return cache;
-// }
-
-// const cache = createUnfinalizedBlockCache();
-
-// const getTxFromCache = (txHash): TransactionReceipt | null => {
-//   const blockNumber = cache.getBlockNumber(txHash);
-//   return blockNumber ? getTransactionReceiptAtBlock(txHash, blockNumber) : null;
-// }

--- a/eth-providers/tsconfig.json
+++ b/eth-providers/tsconfig.json
@@ -23,5 +23,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules/*"]
+  "exclude": ["node_modules/*", "**/__tests__"]
 }

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -229,7 +229,7 @@ class Eip1193BridgeImpl {
     return hexValue(val);
   }
 
-  async _runWithRetries<T>(fn: any, args: any[] = [], maxRetries: number = 15, interval: number = 2000): Promise<T> {
+  async _runWithRetries<T>(fn: any, args: any[] = [], maxRetries: number = 20, interval: number = 1000): Promise<T> {
     let res;
     let tries = 0;
 


### PR DESCRIPTION
## Change
- added a UnfinalizedCache which indexes txHashes from unfinalized blocks. It listens to new heads and keep adding/deleting these txHashes. When we call `getXXXByTxhash`, it will first search for this txHash in cache, if it exist, then it will fetch tx details. We don't need to index all these tx details at first to improve performance.

## Test
- unit tested this class
- hello world is still able to deploy
- prev tests all passed locally
- no integration test since it's hard to reproduce testing environment locally, so I manually tested it by setting up a local node that doesn't produce finalized block (thanks for @zjb0807 's suggestion), so no tx is indexed in subql, and `getXXXByTxhash` still works (all fetched from cache).

## TODO
need more integration test in production env where it produces finalized block dynamically. (probably do this after we have a public testnet)