### PR TITLE
fix subql types and polish

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1078,7 +1078,7 @@ export abstract class BaseProvider extends AbstractProvider {
 
     const filteredLogs = await getFilteredLogs(_filter as Filter);
 
-    return this.formatter.filterLog(filteredLogs);
+    return filteredLogs.map((log) => this.formatter.filterLog(log));
   };
 
   // ENS

--- a/eth-providers/src/utils/queries.ts
+++ b/eth-providers/src/utils/queries.ts
@@ -1,7 +1,6 @@
 import { BlockTag, Filter, Log } from '@ethersproject/abstract-provider';
 import { request, gql } from 'graphql-request';
-import { TransactionReceipt, Query, LogFilter } from './gqlTypes';
-export * from './gqlTypes';
+import { Query, TransactionReceipt as TXReceiptGQL, Log as LogGQL } from './gqlTypes';
 
 const URL = 'http://localhost:3001';
 
@@ -48,7 +47,7 @@ const TX_RECEIPT_NODES = `
   }
 `;
 
-export const getAllTxReceipts = async (): Promise<TransactionReceipt[]> => {
+export const getAllTxReceipts = async (): Promise<TXReceiptGQL[]> => {
   const res = await queryGraphql(`
     query {
       transactionReceipts {
@@ -57,10 +56,10 @@ export const getAllTxReceipts = async (): Promise<TransactionReceipt[]> => {
     }
   `);
 
-  return res.transactionReceipts!.nodes as TransactionReceipt[];
+  return res.transactionReceipts!.nodes as TXReceiptGQL[];
 };
 
-export const getTxReceiptByHash = async (hash: string): Promise<TransactionReceipt | null> => {
+export const getTxReceiptByHash = async (hash: string): Promise<TXReceiptGQL | null> => {
   const res = await queryGraphql(`
     query {
       transactionReceipts(filter: {
@@ -124,6 +123,13 @@ export const getLogsQueryFilter = (filter: Filter): string => {
   return queryFilter;
 };
 
+// adapt logs from graphql to provider compatible types
+const _adaptLogs = (logs: LogGQL[]): Log[] =>
+  logs.map((log) => ({
+    ...log,
+    data: log.data || ''
+  }));
+
 export const getAllLogs = async (): Promise<Log[]> => {
   const res = await queryGraphql(`
     query {
@@ -133,7 +139,7 @@ export const getAllLogs = async (): Promise<Log[]> => {
     }
   `);
 
-  return res.logs!.nodes as Log[];
+  return _adaptLogs(res.logs!.nodes as LogGQL[]);
 };
 
 export const getFilteredLogs = async (filter: Filter): Promise<Log[]> => {
@@ -147,5 +153,5 @@ export const getFilteredLogs = async (filter: Filter): Promise<Log[]> => {
     }
   `);
 
-  return res.logs!.nodes as Log[];
+  return _adaptLogs(res.logs!.nodes as LogGQL[]);
 };

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -21,7 +21,7 @@ const rpcGet =
 export const logsEq = (a: Log[], b: Log[]): boolean =>
   a.length === b.length &&
   a.every(({ transactionHash: t0, logIndex: l0 }) =>
-    b.find(({ transactionHash: t1, logIndex: l1 }) => t0 === t1 && l0 === l1)
+    b.find(({ transactionHash: t1, logIndex: l1 }) => t0 === t1 && parseInt(l0) === parseInt(l1))
   );
 
 describe('eth_getTransactionReceipt', () => {

--- a/eth-rpc-adapter/tsconfig.json
+++ b/eth-rpc-adapter/tsconfig.json
@@ -23,5 +23,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules/*"]
+  "exclude": ["node_modules/*", "**/__tests__"]
 }


### PR DESCRIPTION
## Change
- previously there are some type naming conflicts, both subql side and provider side has `TransactionReceipt` type (and slightly difference definition. This commit fixed the types and be more precise.
- fix a bug when using formatter.

## Test
- `yarn test:dev` for `eth-rpc-adaptor` passed locally
- `yarn test:dev` for `eth-providers` passed locally
- hello world tests still work