### PR TITLE
get logs support hex string

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1111,11 +1111,15 @@ export abstract class BaseProvider extends AbstractProvider {
         return 0;
       }
       default: {
-        if (typeof blockTag !== 'number') {
-          return logger.throwArgumentError("blocktag should be number | 'latest' | 'earliest'", 'blockTag', blockTag);
+        if (isHexString(blockTag) || typeof blockTag === 'number') {
+          return BigNumber.from(blockTag).toNumber();
         }
 
-        return blockTag;
+        return logger.throwArgumentError(
+          "blocktag should be number | hex string | 'latest' | 'earliest'",
+          'blockTag',
+          blockTag
+        );
       }
     }
   };

--- a/eth-rpc-adapter/package.json
+++ b/eth-rpc-adapter/package.json
@@ -12,7 +12,7 @@
     "test": "mocha **/*.test.ts --ignore **/e2e/**",
     "test:dev": "mocha **/*.test.ts --watch --watch-files **/*.test.ts",
     "start": "ts-node src/index",
-    "dev": "nodemon --watch \"*\" --ext \"js,ts,json\" --ignore \"src/**/*.spec.ts\" --exec \"ts-node src/index.ts\" | pino-pretty"
+    "dev": "nodemon --watch \"*\" --ext \"js,ts,json\" --ignore \"src/**/*.{spec,test}.ts\" --exec \"ts-node src/index.ts\" | pino-pretty"
   },
   "dependencies": {
     "@acala-network/eth-providers": "workspace:*",

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -110,6 +110,7 @@ describe('eth_getLogs', () => {
   describe('filter by block number', () => {
     it('returns correct logs', async () => {
       const BIG_NUMBER = 88888888;
+      const BIG_NUMBER_HEX = '0x54C5638';
       const allLogs = await getAllLogs();
       let res;
       let expectedLogs;
@@ -124,6 +125,10 @@ describe('eth_getLogs', () => {
       expect(logsEq(res.data.result, allLogs)).to.equal(true);
 
       res = await eth_getLogs([{ fromBlock: -100000, toBlock: BIG_NUMBER }]);
+      expect(res.status).to.equal(200);
+      expect(logsEq(res.data.result, allLogs)).to.equal(true);
+
+      res = await eth_getLogs([{ fromBlock: -100000, toBlock: BIG_NUMBER_HEX }]);
       expect(res.status).to.equal(200);
       expect(logsEq(res.data.result, allLogs)).to.equal(true);
 
@@ -171,6 +176,18 @@ describe('eth_getLogs', () => {
       expect(res.status).to.equal(200);
       expect(logsEq(res.data.result, allLogs)).to.equal(true);
 
+      res = await eth_getLogs([{ fromBlock: 0 }]);
+      expect(res.status).to.equal(200);
+      expect(logsEq(res.data.result, allLogs)).to.equal(true);
+
+      res = await eth_getLogs([{ fromBlock: '0x0' }]);
+      expect(res.status).to.equal(200);
+      expect(logsEq(res.data.result, allLogs)).to.equal(true);
+
+      res = await eth_getLogs([{ fromBlock: '0x00000000' }]);
+      expect(res.status).to.equal(200);
+      expect(logsEq(res.data.result, allLogs)).to.equal(true);
+
       res = await eth_getLogs([{ fromBlock: 'earliest', toBlock: 'latest' }]);
       expect(res.status).to.equal(200);
       expect(logsEq(res.data.result, allLogs)).to.equal(true);
@@ -180,6 +197,9 @@ describe('eth_getLogs', () => {
       expect(res.data.result).to.deep.equal([]);
 
       res = await eth_getLogs([{ fromBlock: 'latest', toBlock: 5 }]);
+      expect(res.data.result).to.deep.equal([]);
+
+      res = await eth_getLogs([{ fromBlock: 'latest', toBlock: '0x5' }]);
       expect(res.data.result).to.deep.equal([]);
 
       res = await eth_getLogs([{ fromBlock: 8, toBlock: 'earliest' }]);
@@ -205,10 +225,19 @@ describe('eth_getLogs', () => {
     });
 
     it('returns correct error code and messge for invalid tag', async () => {
-      const res = await eth_getLogs([{ fromBlock: 'polkadot' }]);
+      let res;
+
+      /* ---------- invalid tag ---------- */
+      res = await eth_getLogs([{ fromBlock: 'polkadot' }]);
       expect(res.status).to.equal(200);
       expect(res.data.error.code).to.equal(-32602);
-      expect(res.data.error.message).to.contain("blocktag should be number | 'latest' | 'earliest'");
+      expect(res.data.error.message).to.contain("blocktag should be number | hex string | 'latest' | 'earliest'");
+
+      /* ---------- invalid hex string ---------- */
+      res = await eth_getLogs([{ toBlock: '0xzzzz' }]);
+      expect(res.status).to.equal(200);
+      expect(res.data.error.code).to.equal(-32602);
+      expect(res.data.error.message).to.contain("blocktag should be number | hex string | 'latest' | 'earliest'");
     });
   });
 

--- a/evm-subql/README.md
+++ b/evm-subql/README.md
@@ -40,7 +40,7 @@ npm i -g @subql/node @subql/query
 
 - run an [Acala](https://github.com/AcalaNetwork/Acala) node locally and listen to port 9944 (in terminal 1)
 ```
-docker run -it --rm -p 9944:9944 -p 9933:9933 acala/mandala-node:2.0.2 --dev --ws-externatrue --rpc-port=9933 --rpc-external=true --rpc-cors=all --rpc-methods=unsafe --tmp [--instant-sealing]
+docker run -it --rm -p 9944:9944 -p 9933:9933 acala/mandala-node:2.0.2 --dev --ws-external=true --rpc-port=9933 --rpc-external=true --rpc-cors=all --rpc-methods=unsafe --tmp [--instant-sealing]
 ```
 
 - feed some EVM transactions to Acala node (this step is *REQUIRED* if run acala node with `--instant-sealing`, otherwise it is optional)

--- a/evm-subql/README.md
+++ b/evm-subql/README.md
@@ -40,10 +40,10 @@ npm i -g @subql/node @subql/query
 
 - run an [Acala](https://github.com/AcalaNetwork/Acala) node locally and listen to port 9944 (in terminal 1)
 ```
-docker run -it --rm -p 9944:9944 -p 9933:9933 acala/mandala-node:2.0.2 --dev --ws-external=true --rpc-port=9933 --rpc-external=true --rpc-cors=all --rpc-methods=unsafe
+docker run -it --rm -p 9944:9944 -p 9933:9933 acala/mandala-node:2.0.2 --dev --ws-externatrue --rpc-port=9933 --rpc-external=true --rpc-cors=all --rpc-methods=unsafe --tmp [--instant-sealing]
 ```
 
-- feed some EVM transactions to Acala node
+- feed some EVM transactions to Acala node (this step is *REQUIRED* if run acala node with `--instant-sealing`, otherwise it is optional)
 ```
 cd ../examples/waffle/dex
 yarn test


### PR DESCRIPTION
## Change
`getLogs` added support for hex string

## Test
added tests for using hex string, and all tests for `eth-rpc-adaptor` still pass