### PR TITLE
Support indexing scheduler evm event

### DIFF
--- a/evm-subql/src/mappings/mappingHandlers.ts
+++ b/evm-subql/src/mappings/mappingHandlers.ts
@@ -6,7 +6,7 @@ import { SubstrateEvent } from '@subql/types';
 import { Log, TransactionReceipt } from '../types';
 
 const NOT_EXIST_TRANSACTION_INDEX = 0xffff;
-const DUMMY_TX_HASH = '0x6666666666666';
+const DUMMY_TX_HASH = '0x6666666666666666666666666666666666666666666666666666666666666666';
 
 export async function handleEvmEvent(event: SubstrateEvent): Promise<void> {
   const { block } = event;

--- a/evm-subql/src/mappings/mappingHandlers.ts
+++ b/evm-subql/src/mappings/mappingHandlers.ts
@@ -6,14 +6,16 @@ import { SubstrateEvent } from '@subql/types';
 import { Log, TransactionReceipt } from '../types';
 
 const NOT_EXIST_TRANSACTION_INDEX = 0xffff;
+const DUMMY_TX_HASH = '0x6666666666666';
 
 export async function handleEvmEvent(event: SubstrateEvent): Promise<void> {
   const { block } = event;
 
   const txIdx = event.extrinsic?.idx ?? NOT_EXIST_TRANSACTION_INDEX;
 
+  const transactionHash = event.extrinsic?.extrinsic.hash.toHex() || DUMMY_TX_HASH;
   const transactionInfo = {
-    transactionHash: event.extrinsic.extrinsic.hash.toHex(),
+    transactionHash,
     blockNumber: block.block.header.number.toNumber(),
     blockHash: block.block.hash.toHex(),
     transactionIndex: txIdx
@@ -47,7 +49,7 @@ export async function handleEvmEvent(event: SubstrateEvent): Promise<void> {
   for (const [idx, evmLog] of ret.logs.entries()) {
     const log = Log.create({
       id: `${receiptId}-${idx}`,
-      transactionHash: event.extrinsic.extrinsic.hash.toHex(),
+      transactionHash,
       blockNumber: block.block.header.number.toNumber(),
       blockHash: block.block.hash.toHex(),
       transactionIndex: txIdx,


### PR DESCRIPTION
## Change
Previously if an evm event is triggered by scheduler, it has no extrinsics, so when trying to get tx hash from extrinsic, it will crash subql. So we added this dummy tx hash for these kind of event.

Note that I chose a very distinguishable dummy tx hash (instead of `0x`), so if this is causing any problem in the future, we will know immediately what is the cause, since the error msg will look something like
```
ERROR: can't find tx hash 0x6666666666666666666666666666666666666666666666666666666666666666
```

## Test
Ran all waffle examples, previously it will crash subql, now it won't. And so far there is no known way to crash subql anymore :tada: