### PR TITLE
able to pass subql-url as env

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -110,6 +110,7 @@ importers:
       bn.js: 4.12.0
       chai: ~4.3.4
       chai-as-promised: ~7.1.1
+      dotenv: ~10.0.0
       eslint: ~7.32.0
       ethers: ~5.4.7
       graphql: ~16.0.1
@@ -136,6 +137,7 @@ importers:
       '@polkadot/util': 7.9.2
       '@polkadot/util-crypto': 7.9.2
       bn.js: 4.12.0
+      dotenv: 10.0.0
       ethers: 5.4.7
       graphql: 16.0.1
       graphql-request: 3.6.1_graphql@16.0.1

--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -34,7 +34,8 @@
     "graphql": "~16.0.1",
     "graphql-request": "~3.6.1",
     "@graphql-codegen/typescript": "2.3.0",
-    "@ethersproject/providers": "~5.5.0"
+    "@ethersproject/providers": "~5.5.0",
+    "dotenv": "~10.0.0"
   },
   "devDependencies": {
     "@types/chai": "~4.2.22",

--- a/eth-providers/src/utils/queries.ts
+++ b/eth-providers/src/utils/queries.ts
@@ -1,8 +1,11 @@
 import { BlockTag, Filter, Log } from '@ethersproject/abstract-provider';
 import { request, gql } from 'graphql-request';
+import dotenv from 'dotenv';
 import { Query, TransactionReceipt as TXReceiptGQL, Log as LogGQL } from './gqlTypes';
 
-const URL = 'http://localhost:3001';
+dotenv.config();
+
+const URL = process.env.SUBQL_URL || 'http://localhost:3001';
 
 const queryGraphql = (query: string): Promise<Query> =>
   request(

--- a/eth-rpc-adapter/.env.sample
+++ b/eth-rpc-adapter/.env.sample
@@ -1,2 +1,4 @@
-ENDPOINT_URL=ws://0.0.0.0::9944
+ENDPOINT_URL=ws://localhost:9944
+SUBQL_URL=http://localhost:3001
 HTTP_PORT=8545
+WS_PORT=3331

--- a/eth-rpc-adapter/README.md
+++ b/eth-rpc-adapter/README.md
@@ -4,13 +4,16 @@ A node service that allows existing Ethereum dApp to be able to interact with [A
 ## Run
 - provide an optional `.env` file for:
   - **ENDPOINT_URL**: acala node WS url
+  - **SUBQL_URL**: subquery service url
   - **HTTP_PORT**: HTTP port for requests
   - **WS_PORT**: WS port for requests
 
-for example:
+for example checkout `.env.sample`:
 ```
-ENDPOINT_URL=ws://localhost:9944  # default WS port that acala node exposes
-HTTP_PORT=8545                    # default http port that hardhat looks for
+ENDPOINT_URL=ws://localhost:9944 # default WS port that acala node exposes
+SUBQL_URL=http://localhost:3001  # default http port that subquery exposes
+HTTP_PORT=8545                   # default http port that hardhat looks for
+WS_PORT=3331
 ```
 
 - install dependencies

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -253,7 +253,7 @@ class Eip1193BridgeImpl {
         res = await fn(...args);
       } catch (e) {
         console.log(`failed attemp # ${tries}/${maxRetries}`);
-        if (tries === maxRetries) {
+        if (tries === maxRetries || !(e as any).message.includes('transaction hash not found')) {
           throw e;
         }
         await sleep(interval);

--- a/eth-rpc-adapter/src/server.ts
+++ b/eth-rpc-adapter/src/server.ts
@@ -39,5 +39,6 @@ export async function start() {
   await provider.isReady();
 
   console.log(`server started with ${ENDPOINT_URL}`);
+  console.log(`subquery url: ${process.env.SUBQL_URL}`);
   console.log(`listening to: HTTP ${HTTP_PORT}, WS: ${WS_PORT}`);
 }


### PR DESCRIPTION
## Change
Previously providers can only query a hard-coded subql endpoint, which is `localhost:3001`. In order for it to query our public subql service in the future, we need to be able to pass a custom url as env variable. This commit adds this functionality.

In the future we can probably further polish the whole subquery helper functions to a provider, but let's get the functionalities working and make the deployment work first.

## Test
tested with different `SUBQL_URL` variable, and queries are querying the correct endpoint