### PR TITLE
added mandala public testnet config

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -307,6 +307,7 @@ importers:
 
   ../../examples/hardhat:
     specifiers:
+      '@acala-network/eth-providers': workspace:*
       '@nomiclabs/hardhat-ethers': ^2.0.0
       '@nomiclabs/hardhat-etherscan': ^2.1.3
       '@nomiclabs/hardhat-waffle': ^2.0.0
@@ -338,6 +339,7 @@ importers:
       typechain: ^5.1.2
       typescript: ~4.4.4
     devDependencies:
+      '@acala-network/eth-providers': link:../../eth-providers
       '@nomiclabs/hardhat-ethers': 2.0.2_ethers@5.4.7+hardhat@2.7.0
       '@nomiclabs/hardhat-etherscan': 2.1.8_hardhat@2.7.0
       '@nomiclabs/hardhat-waffle': 2.0.1_2cd909a2c50cb55545f7606ca367297e
@@ -6232,7 +6234,7 @@ packages:
     resolution: {integrity: sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==}
     deprecated: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
     dependencies:
-      follow-redirects: 1.14.5
+      follow-redirects: 1.14.5_debug@4.3.2
     transitivePeerDependencies:
       - debug
     dev: false
@@ -6241,7 +6243,7 @@ packages:
   /axios/0.24.0:
     resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
     dependencies:
-      follow-redirects: 1.14.5
+      follow-redirects: 1.14.5_debug@4.3.2
     transitivePeerDependencies:
       - debug
     dev: false
@@ -10714,7 +10716,7 @@ packages:
     resolution: {integrity: sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s=}
     dev: true
 
-  /follow-redirects/1.14.5:
+  /follow-redirects/1.14.5_debug@4.3.2:
     resolution: {integrity: sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -10722,6 +10724,8 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dependencies:
+      debug: 4.3.2
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -17798,7 +17802,7 @@ packages:
     dependencies:
       command-exists: 1.2.9
       commander: 3.0.2
-      follow-redirects: 1.14.5
+      follow-redirects: 1.14.5_debug@4.3.2
       fs-extra: 0.30.0
       js-sha3: 0.8.0
       memorystream: 0.3.1

--- a/examples/hardhat/hardhat.config.ts
+++ b/examples/hardhat/hardhat.config.ts
@@ -27,6 +27,12 @@ const config: HardhatUserConfig = {
       chainId: 595,
       // Development built-in default deployment account
       accounts: ['0xa872f6cbd25a0e04a08b1e21098017a9e6194d101d75e13111f71410c59cd57f']
+    },
+    mandalaPub: {
+      url: 'https://tc7-eth.aca-dev.network',
+      chainId: 595,
+      // Development built-in default deployment account
+      accounts: ['0xa872f6cbd25a0e04a08b1e21098017a9e6194d101d75e13111f71410c59cd57f']
     }
   },
   mocha: {

--- a/examples/hardhat/hardhat.config.ts
+++ b/examples/hardhat/hardhat.config.ts
@@ -26,8 +26,7 @@ const config: HardhatUserConfig = {
       url: 'http://localhost:8545',
       chainId: 595,
       // Development built-in default deployment account
-      accounts: ['0xa872f6cbd25a0e04a08b1e21098017a9e6194d101d75e13111f71410c59cd57f'],
-      gasPrice: 429496729610000
+      accounts: ['0xa872f6cbd25a0e04a08b1e21098017a9e6194d101d75e13111f71410c59cd57f']
     }
   },
   mocha: {

--- a/examples/hardhat/package.json
+++ b/examples/hardhat/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "hardhat compile",
     "test": "hardhat test --network mandala",
-    "deploy": "TS_NODE_FILES=true npx ts-node scripts/deploy.ts"
+    "deploy": "TS_NODE_TRANSPILE_ONLY=true hardhat run scripts/deploy.ts --network mandala"
   },
   "dependencies": {},
   "devDependencies": {

--- a/examples/hardhat/package.json
+++ b/examples/hardhat/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@acala-network/eth-providers": "workspace:*",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-etherscan": "^2.1.3",
     "@nomiclabs/hardhat-waffle": "^2.0.0",

--- a/examples/hardhat/package.json
+++ b/examples/hardhat/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "build": "hardhat compile",
     "test": "hardhat test --network mandala",
-    "deploy": "TS_NODE_TRANSPILE_ONLY=true hardhat run scripts/deploy.ts --network mandala"
+    "deploy": "TS_NODE_TRANSPILE_ONLY=true hardhat run scripts/deploy.ts --network mandala",
+    "test:pub": "hardhat test --network mandalaPub",
+    "deploy:pub": "TS_NODE_TRANSPILE_ONLY=true hardhat run scripts/deploy.ts --network mandalaPub"
   },
   "dependencies": {},
   "devDependencies": {

--- a/examples/hardhat/scripts/deploy.ts
+++ b/examples/hardhat/scripts/deploy.ts
@@ -4,6 +4,10 @@
 // When running the script with `npx hardhat run <script>` you'll find the Hardhat
 // Runtime Environment's members available in the global scope.
 import { ethers } from 'hardhat';
+import { calcEthereumTransactionParams } from '@acala-network/eth-providers';
+
+const txFeePerGas = '199999946752';
+const storageByteDeposit = '100000000000000';
 
 async function main() {
   // Hardhat always runs the compile task when running scripts with its command
@@ -13,9 +17,20 @@ async function main() {
   // manually to make sure everything is compiled
   // await hre.run('compile');
 
+  const ethParams = calcEthereumTransactionParams({
+    gasLimit: '2100001',
+    validUntil: '360001',
+    storageLimit: '64001',
+    txFeePerGas,
+    storageByteDeposit
+  });
+
   // We get the contract to deploy
   const HelloWorld = await ethers.getContractFactory('HelloWorld');
-  const contract = await HelloWorld.deploy('Hello, Hardhat!');
+  const contract = await HelloWorld.deploy('Hello, Hardhat!', {
+    gasPrice: ethParams.txGasPrice,
+    gasLimit: ethParams.txGasLimit
+  });
 
   await contract.deployed();
 

--- a/examples/hardhat/test/HelloWorld.test.ts
+++ b/examples/hardhat/test/HelloWorld.test.ts
@@ -1,10 +1,26 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
+import { calcEthereumTransactionParams } from '@acala-network/eth-providers';
 
 describe('HelloWorld', function () {
   it("Should return the new greeting once it's changed", async function () {
+    const txFeePerGas = '199999946752';
+    const storageByteDeposit = '100000000000000';
+
+    const ethParams = calcEthereumTransactionParams({
+      gasLimit: '2100001',
+      validUntil: '360001',
+      storageLimit: '64001',
+      txFeePerGas,
+      storageByteDeposit
+    });
+
     const HelloWorld = await ethers.getContractFactory('HelloWorld');
-    const contract = await HelloWorld.deploy('Hello, world!');
+    const contract = await HelloWorld.deploy('Hello, world!', {
+      gasPrice: ethParams.txGasPrice,
+      gasLimit: ethParams.txGasLimit
+    });
+
     await contract.deployed();
 
     expect(await contract.greet()).to.equal('Hello, world!');

--- a/examples/hardhat/test/HelloWorld.test.ts
+++ b/examples/hardhat/test/HelloWorld.test.ts
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { calcEthereumTransactionParams } from '@acala-network/eth-providers';
 
+const txFeePerGas = '199999946752';
+const storageByteDeposit = '100000000000000';
+
 describe('HelloWorld', function () {
   it("Should return the new greeting once it's changed", async function () {
-    const txFeePerGas = '199999946752';
-    const storageByteDeposit = '100000000000000';
-
     const ethParams = calcEthereumTransactionParams({
       gasLimit: '2100001',
       validUntil: '360001',
@@ -25,7 +25,10 @@ describe('HelloWorld', function () {
 
     expect(await contract.greet()).to.equal('Hello, world!');
 
-    const setGreetingTx = await contract.setGreeting('Hola, mundo!');
+    const setGreetingTx = await contract.setGreeting('Hola, mundo!', {
+      gasPrice: ethParams.txGasPrice,
+      gasLimit: ethParams.txGasLimit
+    });
 
     // wait until the transaction is mined
     await setGreetingTx.wait();

--- a/examples/truffle/package.json
+++ b/examples/truffle/package.json
@@ -13,6 +13,8 @@
   "scripts": {
     "build": "truffle compile",
     "test": "truffle test --network mandala",
-    "deploy": "truffle migrate --network mandala"
+    "deploy": "truffle migrate --network mandala",
+    "test:pub": "truffle test --network mandalaPub",
+    "deploy:pub": "truffle migrate --network mandalaPub"
   }
 }

--- a/examples/truffle/truffle-config.js
+++ b/examples/truffle/truffle-config.js
@@ -46,6 +46,19 @@ module.exports = {
       gas: 34132001,
       timeoutBlocks: 25,
       confirmations: 0
+    },
+    mandalaPub: {
+      provider: () =>
+        new HDWalletProvider(
+          ['0xa872f6cbd25a0e04a08b1e21098017a9e6194d101d75e13111f71410c59cd57f'],
+          'https://tc7-eth.aca-dev.network'
+        ),
+      network_id: 595,
+      gasPrice: 200786445289, // storage_limit = 64001, validUntil = 360001, gasLimit = 2100001
+      gas: 34132001,
+      timeoutBlocks: 25,
+      confirmations: 0,
+      networkCheckTime: 50000
     }
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.

--- a/examples/truffle/truffle-config.js
+++ b/examples/truffle/truffle-config.js
@@ -42,7 +42,8 @@ module.exports = {
           'http://127.0.0.1:8545'
         ),
       network_id: 595,
-      gasPrice: 429496729610000, // storage_limit = 100000, validUntil = 10000, 100000 << 32 | 10000
+      gasPrice: 200786445289, // storage_limit = 100000, validUntil = 10000, 100000 << 32 | 10000
+      gas: 34132001,
       timeoutBlocks: 25,
       confirmations: 0
     }

--- a/examples/truffle/truffle-config.js
+++ b/examples/truffle/truffle-config.js
@@ -42,7 +42,7 @@ module.exports = {
           'http://127.0.0.1:8545'
         ),
       network_id: 595,
-      gasPrice: 200786445289, // storage_limit = 100000, validUntil = 10000, 100000 << 32 | 10000
+      gasPrice: 200786445289, // storage_limit = 64001, validUntil = 360001, gasLimit = 2100001
       gas: 34132001,
       timeoutBlocks: 25,
       confirmations: 0


### PR DESCRIPTION
## Change
we just deployed `eth-rpc-adaptor` today, and this commit added config to truffle and hardhat examples to test with this new public `eth-rpc-adaptor`.

## Test
`yarn test:pub`, `yarn deploy:pub` both passed with the new public eth-rpc-adaptor` :tada::tada: