### PR TITLE
EIP-1559 Support

### DIFF
--- a/eth-providers/src/__tests__/e2e/tx.test.ts
+++ b/eth-providers/src/__tests__/e2e/tx.test.ts
@@ -102,14 +102,14 @@ describe('transaction tests', () => {
 
         expect(parsedTx.from).equal(wallet1.address);
         expect(parsedTx.data).equal(deployHelloWorldData);
-        expect(parsedTx.type).equal(null); // TODO: is this correct expectation?
+        expect(parsedTx.type).equal(null);
         expect(parsedTx.maxPriorityFeePerGas).equal(undefined);
         expect(parsedTx.maxFeePerGas).equal(undefined);
 
         const response = await provider.sendTransaction(rawTx);
         const receipt = await response.wait(0);
 
-        expect(receipt.type).equal(0); // TODO: is this correct expectation?
+        expect(receipt.type).equal(0); // TODO: should be null, need to fix getPartialTransactionReceipt
         expect(receipt.status).equal(1);
         expect(receipt.from).equal(wallet1.address);
       });
@@ -142,7 +142,7 @@ describe('transaction tests', () => {
         const response = await provider.sendTransaction(rawTx);
         const receipt = await response.wait(0);
 
-        expect(receipt.type).equal(0); // TODO: wrong type, need to fix getPartialTransactionReceipt
+        expect(receipt.type).equal(0); // TODO: should be 2, need to fix getPartialTransactionReceipt
         expect(receipt.status).equal(1);
         expect(receipt.from).equal(wallet1.address);
       });
@@ -221,7 +221,6 @@ describe('transaction tests', () => {
         await sendTx(provider.api, extrinsic);
 
         const _balance = await queryBalance(account1.evmAddress);
-        console.log(_balance.toNumber(), balance.toNumber());
         expect(_balance.sub(balance).toBigInt()).equal(amount);
       });
     });

--- a/eth-providers/src/__tests__/e2e/tx.test.ts
+++ b/eth-providers/src/__tests__/e2e/tx.test.ts
@@ -3,6 +3,7 @@ import ADDRESS from '@acala-network/contracts/utils/Address';
 import { BigNumber } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { Wallet } from '@ethersproject/wallet';
+import { parseUnits, Interface } from 'ethers/lib/utils';
 import { createTestPairs } from '@polkadot/keyring/testingPairs';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import { expect } from 'chai';
@@ -24,30 +25,17 @@ dotenv.config();
 
 describe('transaction tests', () => {
   const endpoint = process.env.ENDPOINT_URL || 'ws://127.0.0.1:9944';
-  const account1 = evmAccounts[0];
-  const account2 = evmAccounts[1];
-
   const provider = EvmRpcProvider.from(endpoint);
 
-  const account1Wallet = new Wallet(account1.privateKey).connect(provider as any);
-
-  const acaContract = new Contract(ADDRESS.ACA, ACAABI.abi, account1Wallet);
-
-  const deployHelloWorldData =
-    '0x60806040526040518060400160405280600c81526020017f48656c6c6f20576f726c642100000000000000000000000000000000000000008152506000908051906020019061004f929190610062565b5034801561005c57600080fd5b50610166565b82805461006e90610134565b90600052602060002090601f01602090048101928261009057600085556100d7565b82601f106100a957805160ff19168380011785556100d7565b828001600101855582156100d7579182015b828111156100d65782518255916020019190600101906100bb565b5b5090506100e491906100e8565b5090565b5b808211156101015760008160009055506001016100e9565b5090565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602260045260246000fd5b6000600282049050600182168061014c57607f821691505b602082108114156101605761015f610105565b5b50919050565b61022e806101756000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063c605f76c14610030575b600080fd5b61003861004e565b6040516100459190610175565b60405180910390f35b6000805461005b906101c6565b80601f0160208091040260200160405190810160405280929190818152602001828054610087906101c6565b80156100d45780601f106100a9576101008083540402835291602001916100d4565b820191906000526020600020905b8154815290600101906020018083116100b757829003601f168201915b505050505081565b600081519050919050565b600082825260208201905092915050565b60005b838110156101165780820151818401526020810190506100fb565b83811115610125576000848401525b50505050565b6000601f19601f8301169050919050565b6000610147826100dc565b61015181856100e7565b93506101618185602086016100f8565b61016a8161012b565b840191505092915050565b6000602082019050818103600083015261018f818461013c565b905092915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602260045260246000fd5b600060028204905060018216806101de57607f821691505b602082108114156101f2576101f1610197565b5b5091905056fea26469706673582212204d363ed34111d1be492d4fd086e9f2df62b3c625e89ade31f30e63201ed1e24f64736f6c63430008090033';
-
-  const pairs = createTestPairs();
-  const oneAca = 10n ** BigInt(provider.api.registry.chainDecimals[0]);
-  const Alice = pairs.alice;
-  const queryBalance = () => acaContract.balanceOf(account1.evmAddress);
+  const account1 = evmAccounts[0];
+  const account2 = evmAccounts[1];
+  const wallet1 = new Wallet(account1.privateKey).connect(provider as any);
 
   let chainId: number;
   let storageByteDeposit: bigint;
   let txFeePerGas: bigint;
   let txGasLimit: BigNumber;
   let txGasPrice: BigNumber;
-
-  let partialTx;
 
   before('prepare common variables', async () => {
     await provider.isReady();
@@ -63,146 +51,268 @@ describe('transaction tests', () => {
       txFeePerGas,
       storageByteDeposit
     }));
-
-    partialTx = {
-      chainId,
-      gasLimit: txGasLimit,
-      gasPrice: txGasPrice,
-      data: deployHelloWorldData,
-      value: BigNumber.from(0)
-    };
   });
 
-  after(async () => {
+  after('clean up', async () => {
     await provider.disconnect();
   });
 
-  describe('transfer aca', () => {
+  describe('test deploy contract (hello world)', () => {
+    const deployHelloWorldData =
+      '0x60806040526040518060400160405280600c81526020017f48656c6c6f20576f726c642100000000000000000000000000000000000000008152506000908051906020019061004f929190610062565b5034801561005c57600080fd5b50610166565b82805461006e90610134565b90600052602060002090601f01602090048101928261009057600085556100d7565b82601f106100a957805160ff19168380011785556100d7565b828001600101855582156100d7579182015b828111156100d65782518255916020019190600101906100bb565b5b5090506100e491906100e8565b5090565b5b808211156101015760008160009055506001016100e9565b5090565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602260045260246000fd5b6000600282049050600182168061014c57607f821691505b602082108114156101605761015f610105565b5b50919050565b61022e806101756000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063c605f76c14610030575b600080fd5b61003861004e565b6040516100459190610175565b60405180910390f35b6000805461005b906101c6565b80601f0160208091040260200160405190810160405280929190818152602001828054610087906101c6565b80156100d45780601f106100a9576101008083540402835291602001916100d4565b820191906000526020600020905b8154815290600101906020018083116100b757829003601f168201915b505050505081565b600081519050919050565b600082825260208201905092915050565b60005b838110156101165780820151818401526020810190506100fb565b83811115610125576000848401525b50505050565b6000601f19601f8301169050919050565b6000610147826100dc565b61015181856100e7565b93506101618185602086016100f8565b61016a8161012b565b840191505092915050565b6000602082019050818103600083015261018f818461013c565b905092915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602260045260246000fd5b600060028204905060018216806101de57607f821691505b602082108114156101f2576101f1610197565b5b5091905056fea26469706673582212204d363ed34111d1be492d4fd086e9f2df62b3c625e89ade31f30e63201ed1e24f64736f6c63430008090033';
+
+    let partialDeployTx;
+
+    before(() => {
+      partialDeployTx = {
+        chainId,
+        gasLimit: txGasLimit,
+        gasPrice: txGasPrice,
+        data: deployHelloWorldData,
+        value: BigNumber.from(0)
+      };
+    });
+
+    describe('with wallet', () => {
+      it('succeeds', async () => {
+        const response = await wallet1.sendTransaction({
+          ...partialDeployTx,
+          type: 0
+        });
+        const receipt = await response.wait(0);
+
+        expect(receipt.type).equal(0);
+        expect(receipt.status).equal(1);
+        expect(receipt.from).equal(wallet1.address);
+      });
+    });
+
+    describe('with legacy EIP-155 signature', () => {
+      it('serialize, parse, and send tx correctly', async () => {
+        const unsignedTx: Eip712Transaction = {
+          ...partialDeployTx,
+          nonce: await wallet1.getTransactionCount()
+        };
+
+        const rawTx = await wallet1.signTransaction(unsignedTx);
+        const parsedTx = parseTransaction(rawTx);
+
+        expect(parsedTx.gasPrice.eq(txGasPrice)).equal(true);
+        expect(parsedTx.gasLimit.eq(txGasLimit)).equal(true);
+
+        expect(parsedTx.from).equal(wallet1.address);
+        expect(parsedTx.data).equal(deployHelloWorldData);
+        expect(parsedTx.type).equal(null); // TODO: is this correct expectation?
+        expect(parsedTx.maxPriorityFeePerGas).equal(undefined);
+        expect(parsedTx.maxFeePerGas).equal(undefined);
+
+        const response = await provider.sendTransaction(rawTx);
+        const receipt = await response.wait(0);
+
+        expect(receipt.type).equal(0); // TODO: is this correct expectation?
+        expect(receipt.status).equal(1);
+        expect(receipt.from).equal(wallet1.address);
+      });
+    });
+
+    describe('with EIP-1559 signature', () => {
+      it('serialize, parse, and send tx correctly', async () => {
+        const priorityFee = BigNumber.from(2);
+        const unsignedTx: Eip712Transaction = {
+          ...partialDeployTx,
+          nonce: await wallet1.getTransactionCount(),
+          gasPrice: undefined,
+          maxPriorityFeePerGas: priorityFee,
+          maxFeePerGas: txGasPrice,
+          type: 2
+        };
+
+        const rawTx = await wallet1.signTransaction(unsignedTx);
+        const parsedTx = parseTransaction(rawTx);
+
+        expect(parsedTx.maxFeePerGas.eq(txGasPrice)).equal(true);
+        expect(parsedTx.maxPriorityFeePerGas.eq(priorityFee)).equal(true);
+        expect(parsedTx.gasLimit.eq(txGasLimit)).equal(true);
+
+        expect(parsedTx.from).equal(wallet1.address);
+        expect(parsedTx.data).equal(deployHelloWorldData);
+        expect(parsedTx.type).equal(2);
+        expect(parsedTx.gasPrice).equal(null);
+
+        const response = await provider.sendTransaction(rawTx);
+        const receipt = await response.wait(0);
+
+        expect(receipt.type).equal(0); // TODO: wrong type, need to fix getPartialTransactionReceipt
+        expect(receipt.status).equal(1);
+        expect(receipt.from).equal(wallet1.address);
+      });
+    });
+
+    describe('with EIP-712 signature', () => {
+      it('serialize, parse, and send tx correctly', async () => {
+        const gasLimit = BigNumber.from('0x030dcf');
+        const validUntil = 10000;
+        const storageLimit = 100000;
+
+        const unsignEip712Tx: Eip712Transaction = {
+          ...partialDeployTx,
+          nonce: await wallet1.getTransactionCount(),
+          salt: provider.genesisHash,
+          gasLimit,
+          validUntil,
+          storageLimit,
+          type: 0x60
+        };
+
+        const sig = signTransaction(account1.privateKey, unsignEip712Tx);
+        const rawTx = serializeTransaction(unsignEip712Tx, sig);
+        const parsedTx = parseTransaction(rawTx);
+
+        expect(parsedTx.gasLimit.eq(gasLimit)).equal(true);
+        expect(parsedTx.validUntil.eq(validUntil)).equal(true);
+        expect(parsedTx.storageLimit.eq(storageLimit)).equal(true);
+
+        expect(parsedTx.from).equal(wallet1.address);
+        expect(parsedTx.data).equal(deployHelloWorldData);
+        expect(parsedTx.type).equal(96);
+        expect(parsedTx.maxPriorityFeePerGas).equal(undefined);
+        expect(parsedTx.maxFeePerGas).equal(undefined);
+
+        await provider.sendRawTransaction(rawTx);
+      });
+    });
+  });
+
+  describe('test call contract (transfer ACA)', () => {
+    const ACADigits = provider.api.registry.chainDecimals[0];
+    const acaContract = new Contract(ADDRESS.ACA, ACAABI.abi, wallet1);
+    const iface = new Interface(ACAABI.abi);
+    const queryBalance = (addr) => acaContract.balanceOf(addr) as BigNumber;
+    const transferAmount = parseUnits('100', ACADigits);
+    let partialTransferTX: any;
+
+    before(() => {
+      partialTransferTX = {
+        chainId,
+        to: ADDRESS.ACA,
+        gasLimit: txGasLimit,
+        gasPrice: txGasPrice,
+        data: iface.encodeFunctionData('transfer', [account2.evmAddress, transferAmount]),
+        value: BigNumber.from(0)
+      };
+    });
+
     it('evm address match', () => {
       expect(computeDefaultSubstrateAddress(account1.evmAddress)).to.equal(account1.defaultSubstrateAddress);
       expect(computeDefaultSubstrateAddress(account2.evmAddress)).to.equal(account2.defaultSubstrateAddress);
     });
 
-    it('has correct balance after transfer', async () => {
-      const balance1: BigNumber = await queryBalance();
-      const amount = 100n * oneAca;
-      const extrinsic = provider.api.tx.balances.transfer(account1.defaultSubstrateAddress, amount);
-      await extrinsic.signAsync(Alice);
-      await sendTx(provider.api, extrinsic);
-      const balance2: BigNumber = await queryBalance();
-      expect(balance2.sub(balance1).toBigInt()).equal(amount);
+    describe('with provider', () => {
+      it('has correct balance after transfer', async () => {
+        const pairs = createTestPairs();
+        const alice = pairs.alice;
 
-      /** send to account2 */
-      // const extrinsic2 = provider.api.tx.balances.transfer(account2.defaultSubstrateAddress, amount);
-      // await extrinsic2.signAsync(Alice);
-      // await sendTx(provider.api, extrinsic2);
-    });
-  });
+        const oneAca = 10n ** BigInt(ACADigits);
+        const amount = 1000n * oneAca;
+        const balance = await queryBalance(account1.evmAddress);
 
-  describe('legacy and EIP-155 format', () => {
-    it('serialize, parse, and send raw tx', async () => {
-      const unsignedTx: Eip712Transaction = {
-        ...partialTx,
-        nonce: await provider.getTransactionCount(account1Wallet.address)
-      };
+        const extrinsic = provider.api.tx.balances.transfer(account1.defaultSubstrateAddress, amount);
+        await extrinsic.signAsync(alice);
+        await sendTx(provider.api, extrinsic);
 
-      const rawTx = await account1Wallet.signTransaction(unsignedTx);
-      const parsedTx = parseTransaction(rawTx);
-
-      expect(parsedTx.gasPrice.eq(txGasPrice)).equal(true);
-      expect(parsedTx.gasLimit.eq(txGasLimit)).equal(true);
-
-      expect(parsedTx.from).equal(account1Wallet.address);
-      expect(parsedTx.data).equal(deployHelloWorldData);
-      expect(parsedTx.type).equal(null); // TODO: is this correct expectation?
-      expect(parsedTx.maxPriorityFeePerGas).equal(undefined);
-      expect(parsedTx.maxFeePerGas).equal(undefined);
-
-      const response = await provider.sendTransaction(rawTx);
-      const receipt = await response.wait(0);
-
-      expect(receipt.type).equal(0); // TODO: is this correct expectation?
-      expect(receipt.status).equal(1);
-      expect(receipt.from).equal(account1Wallet.address);
-    });
-  });
-
-  describe('EIP-1559 format', () => {
-    it('serialize, parse, and send raw tx', async () => {
-      const priorityFee = BigNumber.from(2);
-      const unsignedTx: Eip712Transaction = {
-        ...partialTx,
-        nonce: await provider.getTransactionCount(account1Wallet.address),
-        gasPrice: undefined,
-        maxPriorityFeePerGas: priorityFee,
-        maxFeePerGas: txGasPrice,
-        type: 2
-      };
-
-      const rawTx = await account1Wallet.signTransaction(unsignedTx);
-      const parsedTx = parseTransaction(rawTx);
-
-      expect(parsedTx.maxFeePerGas.eq(txGasPrice)).equal(true);
-      expect(parsedTx.maxPriorityFeePerGas.eq(priorityFee)).equal(true);
-      expect(parsedTx.gasLimit.eq(txGasLimit)).equal(true);
-
-      expect(parsedTx.from).equal(account1Wallet.address);
-      expect(parsedTx.data).equal(deployHelloWorldData);
-      expect(parsedTx.type).equal(2);
-      expect(parsedTx.gasPrice).equal(null);
-
-      const response = await provider.sendTransaction(rawTx);
-      const receipt = await response.wait(0);
-
-      expect(receipt.type).equal(0); // TODO: is this correct expectation? why not 2?
-      expect(receipt.status).equal(1);
-      expect(receipt.from).equal(account1Wallet.address);
-    });
-  });
-
-  describe('EIP-712 format', () => {
-    it('wallet send tx', async () => {
-      const response = await account1Wallet.sendTransaction({
-        ...partialTx,
-        type: 0
+        const _balance = await queryBalance(account1.evmAddress);
+        console.log(_balance.toNumber(), balance.toNumber());
+        expect(_balance.sub(balance).toBigInt()).equal(amount);
       });
-      const receipt = await response.wait(0);
-
-      expect(receipt.type).equal(0);
-      expect(receipt.status).equal(1);
-      expect(receipt.from).equal(account1Wallet.address);
     });
 
-    it('serialize, parse, and send raw tx', async () => {
-      const gasLimit = BigNumber.from('0x030dcf');
-      const validUntil = 10000;
-      const storageLimit = 100000;
+    describe('with legacy EIP-155 signature', () => {
+      it('has correct balance after transfer', async () => {
+        const balance1 = await queryBalance(account1.evmAddress);
+        const balance2 = await queryBalance(account2.evmAddress);
 
-      const unsignEip712Tx: Eip712Transaction = {
-        ...partialTx,
-        nonce: await provider.getTransactionCount(account1Wallet.address),
-        salt: provider.genesisHash,
-        gasLimit,
-        validUntil,
-        storageLimit,
-        type: 0x60
-      };
+        const transferTX: Eip712Transaction = {
+          ...partialTransferTX,
+          nonce: await wallet1.getTransactionCount()
+        };
 
-      const eip712sig = signTransaction(account1.privateKey, unsignEip712Tx);
-      const raw712Tx = serializeTransaction(unsignEip712Tx, eip712sig);
-      const parsedTx = parseTransaction(raw712Tx);
+        const rawTx = await wallet1.signTransaction(transferTX);
+        const parsedTx = parseTransaction(rawTx);
 
-      expect(parsedTx.gasLimit.eq(gasLimit)).equal(true);
-      expect(parsedTx.validUntil.eq(validUntil)).equal(true);
-      expect(parsedTx.storageLimit.eq(storageLimit)).equal(true);
+        const response = await provider.sendTransaction(rawTx);
+        const receipt = await response.wait(0);
 
-      expect(parsedTx.from).equal(account1Wallet.address);
-      expect(parsedTx.data).equal(deployHelloWorldData);
-      expect(parsedTx.type).equal(96);
-      expect(parsedTx.maxPriorityFeePerGas).equal(undefined);
-      expect(parsedTx.maxFeePerGas).equal(undefined);
+        const _balance1 = await queryBalance(account1.evmAddress);
+        const _balance2 = await queryBalance(account2.evmAddress);
 
-      await provider.sendRawTransaction(raw712Tx);
+        // TODO: check sender's balance is correct
+        // expect(balance1.sub(_balance1).toNumber()).equal(transferAmount.toNumber() + gasUsed);
+        expect(_balance2.sub(balance2).toNumber()).equal(transferAmount.toNumber());
+      });
+    });
+
+    describe('with EIP-1559 signature', () => {
+      it('has correct balance after transfer', async () => {
+        const balance1 = await queryBalance(account1.evmAddress);
+        const balance2 = await queryBalance(account2.evmAddress);
+
+        const priorityFee = BigNumber.from(2);
+        const transferTX: Eip712Transaction = {
+          ...partialTransferTX,
+          nonce: await wallet1.getTransactionCount(),
+          gasPrice: undefined,
+          maxPriorityFeePerGas: priorityFee,
+          maxFeePerGas: txGasPrice,
+          type: 2
+        };
+
+        const rawTx = await wallet1.signTransaction(transferTX);
+        const parsedTx = parseTransaction(rawTx);
+
+        const response = await provider.sendTransaction(rawTx);
+        const receipt = await response.wait(0);
+
+        const _balance1 = await queryBalance(account1.evmAddress);
+        const _balance2 = await queryBalance(account2.evmAddress);
+
+        // TODO: check sender's balance is correct
+        // expect(balance1.sub(_balance1).toNumber()).equal(transferAmount.toNumber() + gasUsed);
+        expect(_balance2.sub(balance2).toNumber()).equal(transferAmount.toNumber());
+      });
+    });
+
+    describe('with EIP-712 signature', () => {
+      it('has correct balance after transfer', async () => {
+        const balance1 = await queryBalance(account1.evmAddress);
+        const balance2 = await queryBalance(account2.evmAddress);
+
+        const gasLimit = BigNumber.from('0x030dcf');
+        const validUntil = 10000;
+        const storageLimit = 100000;
+
+        const transferTX: Eip712Transaction = {
+          ...partialTransferTX,
+          nonce: await wallet1.getTransactionCount(),
+          salt: provider.genesisHash,
+          gasLimit,
+          validUntil,
+          storageLimit,
+          type: 0x60
+        };
+
+        const sig = signTransaction(account1.privateKey, transferTX);
+        const rawTx = serializeTransaction(transferTX, sig);
+        const parsedTx = parseTransaction(rawTx);
+
+        await provider.sendRawTransaction(rawTx);
+
+        const _balance1 = await queryBalance(account1.evmAddress);
+        const _balance2 = await queryBalance(account2.evmAddress);
+
+        // TODO: check sender's balance is correct
+        // expect(balance1.sub(_balance1).toNumber()).equal(transferAmount.toNumber() + gasUsed);
+        expect(_balance2.sub(balance2).toNumber()).equal(transferAmount.toNumber());
+      });
     });
   });
 });

--- a/eth-providers/src/__tests__/e2e/tx.test.ts
+++ b/eth-providers/src/__tests__/e2e/tx.test.ts
@@ -13,7 +13,7 @@ import { computeDefaultSubstrateAddress } from '../../utils/address';
 import evmAccounts from '../evmAccounts';
 import {
   serializeTransaction,
-  Eip712Transaction,
+  AcalaEvmTX,
   parseTransaction,
   createTransactionPayload,
   signTransaction
@@ -89,7 +89,7 @@ describe('transaction tests', () => {
 
     describe('with legacy EIP-155 signature', () => {
       it('serialize, parse, and send tx correctly', async () => {
-        const unsignedTx: Eip712Transaction = {
+        const unsignedTx: AcalaEvmTX = {
           ...partialDeployTx,
           nonce: await wallet1.getTransactionCount()
         };
@@ -118,7 +118,7 @@ describe('transaction tests', () => {
     describe('with EIP-1559 signature', () => {
       it('serialize, parse, and send tx correctly', async () => {
         const priorityFee = BigNumber.from(2);
-        const unsignedTx: Eip712Transaction = {
+        const unsignedTx: AcalaEvmTX = {
           ...partialDeployTx,
           nonce: await wallet1.getTransactionCount(),
           gasPrice: undefined,
@@ -154,7 +154,7 @@ describe('transaction tests', () => {
         const validUntil = 10000;
         const storageLimit = 100000;
 
-        const unsignEip712Tx: Eip712Transaction = {
+        const unsignEip712Tx: AcalaEvmTX = {
           ...partialDeployTx,
           nonce: await wallet1.getTransactionCount(),
           salt: provider.genesisHash,
@@ -230,7 +230,7 @@ describe('transaction tests', () => {
         const balance1 = await queryBalance(account1.evmAddress);
         const balance2 = await queryBalance(account2.evmAddress);
 
-        const transferTX: Eip712Transaction = {
+        const transferTX: AcalaEvmTX = {
           ...partialTransferTX,
           nonce: await wallet1.getTransactionCount()
         };
@@ -256,7 +256,7 @@ describe('transaction tests', () => {
         const balance2 = await queryBalance(account2.evmAddress);
 
         const priorityFee = BigNumber.from(2);
-        const transferTX: Eip712Transaction = {
+        const transferTX: AcalaEvmTX = {
           ...partialTransferTX,
           nonce: await wallet1.getTransactionCount(),
           gasPrice: undefined,
@@ -289,7 +289,7 @@ describe('transaction tests', () => {
         const validUntil = 10000;
         const storageLimit = 100000;
 
-        const transferTX: Eip712Transaction = {
+        const transferTX: AcalaEvmTX = {
           ...partialTransferTX,
           nonce: await wallet1.getTransactionCount(),
           salt: provider.genesisHash,

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1,4 +1,4 @@
-import { checkSignatureType, Eip712Transaction, parseTransaction } from '@acala-network/eth-transactions';
+import { checkSignatureType, AcalaEvmTX, parseTransaction } from '@acala-network/eth-transactions';
 import type { EvmAccountInfo, EvmContractInfo } from '@acala-network/types/interfaces';
 import {
   EventType,
@@ -667,7 +667,7 @@ export abstract class BaseProvider extends AbstractProvider {
   };
 
   _getSubstrateGasParams = (
-    ethTx: Eip712Transaction
+    ethTx: AcalaEvmTX
   ): {
     gasLimit: bigint;
     storageLimit: bigint;
@@ -743,7 +743,7 @@ export abstract class BaseProvider extends AbstractProvider {
     rawTx: string
   ): Promise<{
     extrinsic: SubmittableExtrinsic<'promise'>;
-    transaction: Eip712Transaction;
+    transaction: AcalaEvmTX;
   }> => {
     await this.getNetwork();
 
@@ -831,7 +831,7 @@ export abstract class BaseProvider extends AbstractProvider {
   };
 
   _wrapTransaction = async (
-    tx: Eip712Transaction,
+    tx: AcalaEvmTX,
     hash: string,
     startBlock: number,
     startBlockHash: string

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -744,8 +744,6 @@ export abstract class BaseProvider extends AbstractProvider {
       const txFeePerGas = (this.api.consts.evm.txFeePerGas as UInt).toBigInt();
       const { maxFeePerGas, gasPrice } = ethTx;
 
-      logger.info(ethTx, '!!!!!!!!!!!!!!!!!! ethTx');
-
       try {
         const params = calcSubstrateTransactionParams({
           txGasPrice: maxFeePerGas || gasPrice || '0',
@@ -757,15 +755,6 @@ export abstract class BaseProvider extends AbstractProvider {
         gasLimit = params.gasLimit.toBigInt();
         validUntil = params.validUntil.toBigInt();
         storageLimit = params.storageLimit.toBigInt();
-
-        logger.info(
-          {
-            gasLimit,
-            validUntil,
-            storageLimit
-          },
-          'params'
-        );
       } catch {
         logger.throwError('bad gasLimit or gasPrice', Logger.errors.INVALID_ARGUMENT, {
           txGasLimit: ethTx.gasLimit.toBigInt(),
@@ -806,10 +795,10 @@ export abstract class BaseProvider extends AbstractProvider {
       era: '0x00', // mortal
       genesisHash: '0x', // ignored
       method: 'Bytes', // don't know waht is this
-      nonce: ethTx.nonce,
       specVersion: 0, // ignored
-      tip: ethTx.maxPriorityFeePerGas?.toNumber() * Number(gasLimit) || 0, // need to be zero
-      transactionVersion: 0 // ignored
+      transactionVersion: 0, // ignored
+      nonce: ethTx.nonce,
+      tip: (ethTx.maxPriorityFeePerGas?.toNumber() || 0) * Number(gasLimit)
     });
 
     logger.debug(

--- a/eth-transactions/src/createTransactionPayload.ts
+++ b/eth-transactions/src/createTransactionPayload.ts
@@ -1,11 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { hexlify } from '@ethersproject/bytes';
 import { logger } from './logger';
-import { Eip712TransactionPayload } from './types';
+import { AcalaEvmTXPayload } from './types';
 
 export const MAX_UINT256 = '0xffffffff';
 
-export const createTransactionPayload = (tx: Eip712TransactionPayload) => {
+export const createTransactionPayload = (tx: AcalaEvmTXPayload) => {
   if (!tx.salt) {
     logger.throwError('eip712tx missing salt');
   }

--- a/eth-transactions/src/parseTransaction.ts
+++ b/eth-transactions/src/parseTransaction.ts
@@ -63,7 +63,7 @@ function _parseEip712Signature(
   // }
 }
 
-export type SignatureType = 'Ethereum' | 'AcalaEip712';
+export type SignatureType = 'Ethereum' | 'AcalaEip712' | 'Eip1559';
 
 // rlp([chainId, salt, nonce, gasLimit, storageLimit, to, value, data, validUntil, eip712sig])
 export function parseEip712(payload: Uint8Array): Eip712Transaction {
@@ -132,9 +132,11 @@ export function checkSignatureType(rawTransaction: BytesLike): SignatureType {
   const payload = arrayify(rawTransaction);
 
   // Ethereum Transactions
-  if (payload[0] > 0x7f || payload[0] === 1 || payload[0] === 2) {
+  if (payload[0] > 0x7f || payload[0] === 1) {
     return 'Ethereum';
   }
+
+  if (payload[0] === 2) return 'Eip1559';
 
   // EIP 712
   if (payload[0] === 96) {

--- a/eth-transactions/src/parseTransaction.ts
+++ b/eth-transactions/src/parseTransaction.ts
@@ -8,7 +8,7 @@ import { parse } from '@ethersproject/transactions';
 import { logger } from './logger';
 import { serializeEip712 } from './serializeTransaction';
 import { transactionHash } from './transactionHash';
-import { Eip712Transaction, UnsignedEip712Transaction } from './types';
+import { AcalaEvmTX, UnsignedAcalaEvmTX } from './types';
 import { verifyTransaction } from './verifyTransaction';
 
 function handleNumber(value: string): BigNumber {
@@ -26,9 +26,9 @@ function handleAddress(value: string): string | null {
 }
 
 function _parseEip712Signature(
-  tx: Eip712Transaction,
+  tx: AcalaEvmTX,
   fields: Array<string>,
-  serialize: (tx: UnsignedEip712Transaction) => string
+  serialize: (tx: UnsignedAcalaEvmTX) => string
 ): void {
   try {
     const recid = handleNumber(fields[0]).toNumber();
@@ -66,14 +66,14 @@ function _parseEip712Signature(
 export type SignatureType = 'Ethereum' | 'AcalaEip712' | 'Eip1559';
 
 // rlp([chainId, salt, nonce, gasLimit, storageLimit, to, value, data, validUntil, eip712sig])
-export function parseEip712(payload: Uint8Array): Eip712Transaction {
+export function parseEip712(payload: Uint8Array): AcalaEvmTX {
   const transaction = RLP.decode(payload.slice(1));
 
   if (transaction.length !== 9 && transaction.length !== 12) {
     logger.throwArgumentError('invalid component count for transaction type: 96', 'payload', hexlify(payload));
   }
 
-  const tx: Eip712Transaction = {
+  const tx: AcalaEvmTX = {
     type: 96,
     chainId: handleNumber(transaction[0]).toNumber(),
     salt: transaction[1],
@@ -109,7 +109,7 @@ export function parseEip712(payload: Uint8Array): Eip712Transaction {
   return tx;
 }
 
-export function parseTransaction(rawTransaction: BytesLike): Eip712Transaction {
+export function parseTransaction(rawTransaction: BytesLike): AcalaEvmTX {
   const payload = arrayify(rawTransaction);
 
   // Ethereum Transactions

--- a/eth-transactions/src/parseTransaction.ts
+++ b/eth-transactions/src/parseTransaction.ts
@@ -131,17 +131,9 @@ export function parseTransaction(rawTransaction: BytesLike): Eip712Transaction {
 export function checkSignatureType(rawTransaction: BytesLike): SignatureType {
   const payload = arrayify(rawTransaction);
 
-  // Ethereum Transactions
-  if (payload[0] > 0x7f || payload[0] === 1) {
-    return 'Ethereum';
-  }
-
-  if (payload[0] === 2) return 'Eip1559';
-
-  // EIP 712
-  if (payload[0] === 96) {
-    return 'AcalaEip712';
-  }
+  if (payload[0] > 0x7f || payload[0] === 1) return 'Ethereum'; // Legacy and EIP-155
+  if (payload[0] === 2) return 'Eip1559'; // EIP-1559
+  if (payload[0] === 96) return 'AcalaEip712'; // Acala EIP-712
 
   return logger.throwError(`unsupported transaction type: ${payload[0]}`, Logger.errors.UNSUPPORTED_OPERATION, {
     operation: 'checkSignatureType',

--- a/eth-transactions/src/serializeTransaction.ts
+++ b/eth-transactions/src/serializeTransaction.ts
@@ -6,7 +6,7 @@ import * as RLP from '@ethersproject/rlp';
 import { serialize, UnsignedTransaction } from '@ethersproject/transactions';
 import { MAX_UINT256 } from './createTransactionPayload';
 import { logger } from './logger';
-import { UnsignedEip712Transaction } from './types';
+import { UnsignedAcalaEvmTX } from './types';
 
 function formatNumber(value: BigNumberish, name: string): Uint8Array {
   const result = stripZeros(BigNumber.from(value).toHexString());
@@ -17,7 +17,7 @@ function formatNumber(value: BigNumberish, name: string): Uint8Array {
 }
 
 // rlp([chainId, salt, nonce, gasLimit, storageLimit, to, value, data, validUntil, eip712sig])
-export function serializeEip712(transaction: UnsignedEip712Transaction, signature?: SignatureLike) {
+export function serializeEip712(transaction: UnsignedAcalaEvmTX, signature?: SignatureLike) {
   const fields: any = [
     formatNumber(transaction.chainId || 0, 'chainId'),
     transaction.salt || '0x',
@@ -40,7 +40,7 @@ export function serializeEip712(transaction: UnsignedEip712Transaction, signatur
   return hexConcat(['0x60', RLP.encode(fields)]);
 }
 
-export function serializeTransaction(transaction: UnsignedEip712Transaction, signature?: SignatureLike): string {
+export function serializeTransaction(transaction: UnsignedAcalaEvmTX, signature?: SignatureLike): string {
   // Ethereum Transactions
   if (transaction.type == null || transaction.type === 0 || transaction.type === 1 || transaction.type === 2) {
     return serialize(transaction, signature);
@@ -48,7 +48,7 @@ export function serializeTransaction(transaction: UnsignedEip712Transaction, sig
 
   // eip712
   if (transaction.type === 96) {
-    return serializeEip712(transaction as UnsignedEip712Transaction, signature);
+    return serializeEip712(transaction as UnsignedAcalaEvmTX, signature);
   }
 
   return logger.throwError(`unsupported transaction type: ${transaction.type}`, Logger.errors.UNSUPPORTED_OPERATION, {

--- a/eth-transactions/src/signTransaction.ts
+++ b/eth-transactions/src/signTransaction.ts
@@ -2,9 +2,9 @@ import { joinSignature } from '@ethersproject/bytes';
 import { _TypedDataEncoder } from '@ethersproject/hash';
 import { Wallet } from '@ethersproject/wallet';
 import { createTransactionPayload } from './createTransactionPayload';
-import { Eip712TransactionPayload } from './types';
+import { AcalaEvmTXPayload } from './types';
 
-export const signTransaction = (privateKey: string, tx: Eip712TransactionPayload): string => {
+export const signTransaction = (privateKey: string, tx: AcalaEvmTXPayload): string => {
   const payload = createTransactionPayload(tx);
 
   const wallet = new Wallet(privateKey);

--- a/eth-transactions/src/transactionHash.ts
+++ b/eth-transactions/src/transactionHash.ts
@@ -1,8 +1,8 @@
 import { createTransactionPayload } from './createTransactionPayload';
 import { _TypedDataEncoder } from '@ethersproject/hash';
-import { Eip712TransactionPayload } from './types';
+import { AcalaEvmTXPayload } from './types';
 
-export const transactionHash = (tx: Eip712TransactionPayload): string => {
+export const transactionHash = (tx: AcalaEvmTXPayload): string => {
   const payload = createTransactionPayload(tx);
 
   return _TypedDataEncoder.hash(

--- a/eth-transactions/src/types.ts
+++ b/eth-transactions/src/types.ts
@@ -2,7 +2,7 @@ import { BigNumberish } from '@ethersproject/bignumber';
 import { BytesLike } from '@ethersproject/bytes';
 import { UnsignedTransaction, Transaction } from '@ethersproject/transactions';
 
-export type Eip712TransactionPayload = {
+export type AcalaEvmTXPayload = {
   chainId: BigNumberish;
   salt?: BytesLike;
 
@@ -17,13 +17,13 @@ export type Eip712TransactionPayload = {
   validUntil?: BigNumberish;
 };
 
-export interface Eip712Transaction extends Transaction {
+export interface AcalaEvmTX extends Transaction {
   salt?: BytesLike;
   storageLimit?: BigNumberish;
   validUntil?: BigNumberish;
 }
 
-export interface UnsignedEip712Transaction extends UnsignedTransaction {
+export interface UnsignedAcalaEvmTX extends UnsignedTransaction {
   salt?: BytesLike;
   storageLimit?: BigNumberish;
   validUntil?: BigNumberish;

--- a/eth-transactions/src/verifyTransaction.ts
+++ b/eth-transactions/src/verifyTransaction.ts
@@ -1,8 +1,8 @@
 import { verifyTypedData } from '@ethersproject/wallet';
 import { createTransactionPayload } from './createTransactionPayload';
-import { Eip712TransactionPayload } from './types';
+import { AcalaEvmTXPayload } from './types';
 
-export const verifyTransaction = (tx: Eip712TransactionPayload, signature: string): string => {
+export const verifyTransaction = (tx: AcalaEvmTXPayload, signature: string): string => {
   const payload = createTransactionPayload(tx);
 
   return verifyTypedData(


### PR DESCRIPTION
## Change
- added support for EIP-1559 transactions
- did some code refactor
- added thorough tests for `{ deploy contract, call contract } × { Legacy, EIP-712, EIP-1559 }`

## Test
CI passed:
  - all previous tests still pass.
  - new tests all passed.

## TODO
still need more experiment to be able to integrate with Metamask, since Metamask purely uses RPC calls, so it is not as flexible as using provider/signer directly.