### PR TITLE
EIP-1559 RPC tests

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -165,6 +165,7 @@ importers:
     specifiers:
       '@acala-network/api': ~3.0.3-3
       '@acala-network/eth-providers': workspace:*
+      '@acala-network/eth-transactions': workspace:*
       '@acala-network/types': ~3.0.3-3
       '@ethersproject/abstract-provider': ~5.5.0
       '@ethersproject/abstract-signer': ~5.5.0
@@ -211,6 +212,7 @@ importers:
     dependencies:
       '@acala-network/api': 3.0.3-16_@polkadot+types@6.11.1
       '@acala-network/eth-providers': link:../eth-providers
+      '@acala-network/eth-transactions': link:../eth-transactions
       '@acala-network/types': 3.0.3-16
       '@ethersproject/abstract-provider': 5.5.1
       '@ethersproject/abstract-signer': 5.5.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,8 +126,10 @@ services:
       target: eth-rpc-adapter
     depends_on:
       - eth-rpc-adapter-server
+      - mandala-node
     environment:
       RPC_URL: http://eth-rpc-adapter-server:8545
+      ENDPOINT_URL: ws://mandala-node:9944
     command: yarn test:CI
 
   # helper for hardhat with instant-sealing node

--- a/eth-rpc-adapter/package.json
+++ b/eth-rpc-adapter/package.json
@@ -41,7 +41,8 @@
     "axios": "~0.24.0",
     "@ethersproject/abstract-signer": "~5.5.0",
     "@ethersproject/address": "~5.5.0",
-    "@ethersproject/wallet": "~5.5.0"
+    "@ethersproject/wallet": "~5.5.0",
+    "@acala-network/eth-transactions": "workspace:*"
   },
   "devDependencies": {
     "@types/chai": "~4.2.22",

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -498,13 +498,14 @@ describe('eth_sendRawTransaction', () => {
   });
 
   describe('test call contract (transfer ACA)', () => {
+    const ETHDigits = 18;
     const ACADigits = 12;
     const acaContract = new Contract(ADDRESS.ACA, ACAABI.abi, wallet1);
     const iface = new Interface(ACAABI.abi);
     const queryBalance = async (addr) =>
-      BigNumber.from((await eth_getBalance([addr, 'latest'])).data.result).div(10 ** (18 - 12));
+      BigNumber.from((await eth_getBalance([addr, 'latest'])).data.result).div(10 ** (ETHDigits - ACADigits));
     const transferAmount = parseUnits('100', ACADigits);
-    let partialTransferTX: any;
+    let partialTransferTX: Partial<AcalaEvmTX>;
 
     before(() => {
       partialTransferTX = {

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -368,6 +368,8 @@ describe('eth_sendRawTransaction', () => {
   let txGasPrice: BigNumber;
   let genesisHash: string;
 
+  let api: ApiPromise;
+
   before('prepare common variables', async () => {
     chainId = BigNumber.from((await eth_chainId()).data.result).toNumber();
 
@@ -376,7 +378,7 @@ describe('eth_sendRawTransaction', () => {
 
     const endpoint = process.env.ENDPOINT_URL || 'ws://127.0.0.1:9944';
     const wsProvider = new WsProvider(endpoint);
-    const api = await ApiPromise.create({ provider: wsProvider });
+    api = await ApiPromise.create({ provider: wsProvider });
 
     genesisHash = api.genesisHash.toHex(); // TODO: why EIP-712 salt has to be genesis hash?
 
@@ -387,6 +389,10 @@ describe('eth_sendRawTransaction', () => {
       since after calcSubstrateTransactionParams gasLmit will become super big
                                                                                                             ----- */
     // txGasPrice = BigNumber.from((await eth_gasPrice()).data.result).toHexString();
+  });
+
+  after(async () => {
+    await api.disconnect();
   });
 
   describe('test deploy contract (hello world)', () => {


### PR DESCRIPTION
## Change
Added test cases for `eth_sendRawTransaction` with different signature types, these are also use case examples simulating a pure signer environment, such as metamask.

## Test
- old tests still pass
- new tests tested all combinations of 
```
{ contract_deploy, contract_call } x { legacy, EIP-712, EIP-1559 }
```

## TODO
- currently `eth_gasPrice()` is not compatible with legacy and EIP-1559 yet, need to figure out how to get a legit `gasLimit` for the `gasPrice` returned by `eth_gasPrice()`
- why we have to use genesis hash for EIP-712 salt? otherwise will get bad signature, bug or feature?