### PR TITLE
Polished Unfinalized Cache and `eth_estimateGas`

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -546,7 +546,7 @@ export abstract class BaseProvider extends AbstractProvider {
    */
   estimateGas = async (transaction: Deferrable<TransactionRequest>): Promise<BigNumber> => {
     const resources = await this.estimateResources(transaction);
-    return resources.gas.mul(30);     // TODO: this is a temp gas limit, we should optimize gas limit later
+    return resources.gas.mul(30); // TODO: this is a temp gas limit, we should optimize gas limit later
   };
 
   /**
@@ -770,6 +770,17 @@ export abstract class BaseProvider extends AbstractProvider {
     }
 
     const { storageLimit, validUntil, gasLimit, tip } = this._getSubstrateGasParams(ethTx);
+
+    // TODO: remove this when gas price is more stable
+    logger.info(
+      {
+        storageLimit,
+        validUntil,
+        gasLimit,
+        tip
+      },
+      'TX GAS INFO'
+    );
 
     const extrinsic = this.api.tx.evm.ethCall(
       ethTx.to ? { Call: ethTx.to } : { Create: null },

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -161,7 +161,7 @@ export abstract class BaseProvider extends AbstractProvider {
     }) as unknown as void;
 
     this.api.rpc.chain.subscribeFinalizedHeads(async (header: Header) => {
-      this._cache!.removeTxsAtBlock(header.number.toNumber());
+      this._cache!.handleFinalizedBlock(header.number.toNumber());
     }) as unknown as void;
   };
 

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -546,7 +546,7 @@ export abstract class BaseProvider extends AbstractProvider {
    */
   estimateGas = async (transaction: Deferrable<TransactionRequest>): Promise<BigNumber> => {
     const resources = await this.estimateResources(transaction);
-    return resources.gas;
+    return resources.gas.mul(30);     // TODO: this is a temp gas limit, we should optimize gas limit later
   };
 
   /**

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -136,8 +136,8 @@ export interface TXReceipt extends partialTX {
 }
 
 export interface GasConsts {
-  storageDepositPerByte: bigint,
-  txFeePerGas: bigint,
+  storageDepositPerByte: bigint;
+  txFeePerGas: bigint;
 }
 
 export abstract class BaseProvider extends AbstractProvider {
@@ -546,7 +546,7 @@ export abstract class BaseProvider extends AbstractProvider {
 
   _getGasConsts = (): GasConsts => ({
     storageDepositPerByte: (this.api.consts.evm.storageDepositPerByte as UInt).toBigInt(),
-    txFeePerGas: (this.api.consts.evm.txFeePerGas as UInt).toBigInt(),
+    txFeePerGas: (this.api.consts.evm.txFeePerGas as UInt).toBigInt()
   });
 
   /**
@@ -555,8 +555,14 @@ export abstract class BaseProvider extends AbstractProvider {
    * @returns The estimated gas used by this transaction
    */
   estimateGas = async (transaction: Deferrable<TransactionRequest>): Promise<BigNumber> => {
+    const { storageDepositPerByte, txFeePerGas } = this._getGasConsts();
+    const gasPrice = await transaction.gasPrice || await this.getGasPrice();
+    const storageEntryLimit = BigNumber.from(gasPrice).and(0xffff);
+    const storageEntryDeposit = BigNumber.from(storageDepositPerByte).mul(64);
+    const storageGasLimit = storageEntryLimit.mul(storageEntryDeposit).div(txFeePerGas);
+
     const resources = await this.estimateResources(transaction);
-    return resources.gas;
+    return resources.gas.add(storageGasLimit);
   };
 
   /**
@@ -595,17 +601,11 @@ export abstract class BaseProvider extends AbstractProvider {
         );
 
     const result = await (this.api.rpc as any).evm.estimateResources(from, extrinsic.toHex());
-    const gasLimit = BigNumber.from((result.gas as BN).toString());
-
-    const { storageDepositPerByte, txFeePerGas } = this._getGasConsts();
-    const storageEntryLimit = (ethTx.gasPrice || await this.getGasPrice()).and(0xffff);
-    const storageEntryDeposit = BigNumber.from(storageDepositPerByte).mul(64);
-    const storageGasLimit = storageEntryLimit.mul(storageEntryDeposit).div(txFeePerGas);
 
     return {
-      gas: gasLimit.add(storageGasLimit),
+      gas: BigNumber.from((result.gas as BN).toString()),
       storage: BigNumber.from((result.storage as BN).toString()),
-      weightFee: BigNumber.from((result.weightFee as BN).toString())
+      weightFee: BigNumber.from((result.weightFee as BN).toString()),
     };
   };
 

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1155,7 +1155,7 @@ export abstract class BaseProvider extends AbstractProvider {
   }
 
   _getTxReceiptFromCache = async (txHash: string): Promise<TransactionReceipt | null> => {
-    const targetBlockNumber = await this._cache?.getBlockNumber(txHash);
+    const targetBlockNumber = this._cache?.getBlockNumber(txHash);
     if (!targetBlockNumber) return null;
 
     const targetBlockHash = await this.api.rpc.chain.getBlockHash(targetBlockNumber);

--- a/eth-providers/src/utils/unfinalizedBlockCache.ts
+++ b/eth-providers/src/utils/unfinalizedBlockCache.ts
@@ -7,17 +7,25 @@ interface BlockToHashesMap {
 }
 
 export class UnfinalizedBlockCache {
-  blockTxHashes: BlockToHashesMap = {};
-  allTxHashes: HashToBlockMap = {};
+  blockTxHashes: BlockToHashesMap;
+  allTxHashes: HashToBlockMap;
+  extraBlockCount: number;
+
+  constructor(extraBlockCount: number = 10) {
+    this.blockTxHashes = {};
+    this.allTxHashes = {};
+    this.extraBlockCount = extraBlockCount;
+  }
 
   addTxsAtBlock(blockNumber: number, txHashes: string[]): void {
     txHashes.forEach((h) => (this.allTxHashes[h] = blockNumber));
     this.blockTxHashes[blockNumber] = txHashes;
   }
 
-  removeTxsAtBlock(blockNumber: number): void {
-    this.blockTxHashes[blockNumber]?.forEach((h) => delete this.allTxHashes[h]);
-    delete this.blockTxHashes[blockNumber];
+  handleFinalizedBlock(blockNumber: number): void {
+    const blockToRemove = blockNumber - this.extraBlockCount;
+    this.blockTxHashes[blockToRemove]?.forEach((h) => delete this.allTxHashes[h]);
+    delete this.blockTxHashes[blockToRemove];
   }
 
   getBlockNumber(hash: string): number | undefined {

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -374,8 +374,8 @@ describe('eth_sendRawTransaction', () => {
   before('prepare common variables', async () => {
     chainId = BigNumber.from((await eth_chainId()).data.result).toNumber();
 
-    txGasLimit = BigNumber.from(34132001n);
-    txGasPrice = BigNumber.from(200786445289n);
+    txGasLimit = BigNumber.from(34132001);
+    txGasPrice = BigNumber.from(200786445289);
 
     const endpoint = process.env.ENDPOINT_URL || 'ws://127.0.0.1:9944';
     const wsProvider = new WsProvider(endpoint);

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -634,23 +634,10 @@ describe('eth_sendRawTransaction', () => {
         ])
       ).data.result;
 
-      /* -----
-        TODO: https://github.com/AcalaNetwork/bodhi.js/issues/209
-        currently eth_gasPrice() is not compatible with eth_estimateGas(), if we use these auto generated
-        gasPrice and gasLimit, calcSubstrateTransactionParams will result with bad substrate gas params.
-        So temporarily use hard coded gasPrice and gasLimit.
-                                                                                                    ----- */
-      const hardCodedGasPrice = txGasPrice;
-      const hardCodedGasLimit = txGasLimit;
       return {
-        gasPrice: hardCodedGasPrice,
-        gasLimit: hardCodedGasLimit
+        gasPrice,
+        gasLimit
       };
-
-      // return {
-      //   gasPrice,
-      //   gasLimit,
-      // }
     };
 
     before(() => {


### PR DESCRIPTION
## Change
- modified `eth_estimateGas` to return gasLimit + storageGasLimit, so after decoding substrate gasLimit won't be negative. fixed #209 
- changed unfinalzied block cache to cache for a couple more blocks, fixed #214 

## Test
- manually tested that metamask can send token directly without having to manually change gasLimit/gasPrice
- modified endpoint tests to use auto generated gasPrice/gasLimit from hard coded gas, and tests still passed
- modified tests for unfinalized cache according to the new behavoir

## Note
These RPCs are intended for metamask auto generated TX to work (such as sending token). However, when deploying a contract, developer still need to calculate gas params himself, since the default storage limit is 640, which is too small to complex TX.