### PR TITLE
remove EIP-1559 field for getBlock

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -354,7 +354,7 @@ export abstract class BaseProvider extends AbstractProvider {
       author: author,
       extraData: EMPTY_STRING,
 
-      baseFeePerGas: BIGNUMBER_ZERO,
+      // baseFeePerGas: BIGNUMBER_ZERO,
       transactions
     };
 


### PR DESCRIPTION
## Change
As discussed in #213 , we will make Metamask use Legacy format to send token, and it will do it if it doesn't see EIP-1559 fields in block data.

fix #213 

## Test
- Previously we already had test for metamask sending token using legacy format, they still pass
- manually did some testing and sending tokens still work