### PR TITLE
added net_cacheInfo

### DIFF
--- a/eth-providers/src/__tests__/cache.test.ts
+++ b/eth-providers/src/__tests__/cache.test.ts
@@ -23,7 +23,13 @@ describe('UnfinalizedBlockCache', () => {
 
   describe('add block', () => {
     it('correctly find cached transactions', () => {
-      chain.forEach((transactions, idx) => cache.addTxsAtBlock(idx, transactions));
+      chain.forEach((transactions, idx) => {
+        cache.addTxsAtBlock(idx, transactions);
+
+        const { cachedBlocks } = cache._inspect();
+        expect(Number(cachedBlocks[0])).to.equal(0);
+        expect(Number(cachedBlocks[cachedBlocks.length - 1])).to.equal(idx);
+      });
 
       for (let blockNumber = 0; blockNumber < TOTAL_BLOCKS; blockNumber++) {
         for (const curTx of chain[blockNumber]) {
@@ -56,6 +62,10 @@ describe('UnfinalizedBlockCache', () => {
             expect(cache.getBlockNumber(tx)).to.equal(ufbn);
           }
         }
+
+        const { cachedBlocks } = cache._inspect();
+        expect(Number(cachedBlocks[0])).to.equal(blockNumber - EXTRA_BLOCK_COUNT + 1);
+        expect(Number(cachedBlocks[cachedBlocks.length - 1])).to.equal(TOTAL_BLOCKS - 1);
       }
     });
   });

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -354,11 +354,11 @@ export abstract class BaseProvider extends AbstractProvider {
       author: author,
       extraData: EMPTY_STRING,
 
-      transactions,
+      transactions
 
       // with this field Metamask will send token with EIP-1559 format
       // but we want it to send with legacy format
-      // baseFeePerGas: BIGNUMBER_ZERO,   
+      // baseFeePerGas: BIGNUMBER_ZERO,
     };
 
     // @TODO remove ts-ignore
@@ -1326,6 +1326,10 @@ export abstract class BaseProvider extends AbstractProvider {
   getIndexerMetadata = async () => {
     return getIndexerMetadata();
   };
+
+  getUnfinalizedCachInfo = (): any => (
+    this._cache?._inspect() || 'no cache running!'
+  );
 
   // ENS
   lookupAddress = (address: string | Promise<string>): Promise<string> => throwNotImplemented('lookupAddress');

--- a/eth-providers/src/utils/unfinalizedBlockCache.ts
+++ b/eth-providers/src/utils/unfinalizedBlockCache.ts
@@ -31,4 +31,12 @@ export class UnfinalizedBlockCache {
   getBlockNumber(hash: string): number | undefined {
     return this.allTxHashes[hash];
   }
+
+  _inspect = (): any => ({
+    extraBlockCount: this.extraBlockCount,
+    cachedBlocksCount: Object.keys(this.blockTxHashes).length,
+    cachedBlocks: Object.keys(this.blockTxHashes),
+    allBlockToHash: this.blockTxHashes,
+    allHashToBlock: this.allTxHashes
+  });
 }

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -58,6 +58,12 @@ class Eip1193BridgeImpl {
     return this.#provider.getIndexerMetadata();
   }
 
+  // query unfinalized cache info for dev debugging use
+  async net_cacheInfo(params: any[]): Promise<any> {
+    validate([], params);
+    return this.#provider.getUnfinalizedCachInfo();
+  }
+
   /**
    * Returns the current network id.
    * @returns ID - The current network id.


### PR DESCRIPTION
## Change
Added a RPC method to query unfinalized cache internal data, which enable us to monitor if the production cache works as expected

After this we can deploy a new version of RPC stack and see how it goes

## Test
Added tests accordingly to make sure this method returns correct info about the cache