### PR TITLE
roll back prod version to old subql

### DIFF
--- a/evm-subql/Dockerfile
+++ b/evm-subql/Dockerfile
@@ -24,7 +24,7 @@ RUN yarn && yarn build
 
 # =============
 
-FROM onfinality/subql-node:latest
+FROM onfinality/subql-node:v0.25.4-7
 LABEL maintainer="hello@acala.network"
 
 WORKDIR /app


### PR DESCRIPTION
subql new version has breaking changes, so we need to roll back.

In order to use latest subql, we need to first upgrade subql config and codes accordingly