### PR TITLE
implement `eth_subscribe`

### DIFF
--- a/eth-providers/src/__tests__/utils.test.ts
+++ b/eth-providers/src/__tests__/utils.test.ts
@@ -1,0 +1,95 @@
+import { expect } from 'chai';
+import { toHex, filterLog } from '../utils';
+
+describe('filterLog', () => {
+  const topic1 = '0x1111111111111111111111111111111111111111111111111111111111111111';
+  const topic2 = '0x2222222222222222222222222222222222222222222222222222222222222222';
+  const topic3 = '0x3333333333333333333333333333333333333333333333333333333333333333';
+
+  const addr1 = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const addr2 = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const addr3 = '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+  const partialLog = {
+    logIndex: '0x0',
+    transactionIndex: '0x0',
+    transactionHash: '0xfd4ab44cad28fb7902faf7db76a7f475c5d65c6758c8ed9907d7c8351d53bd98',
+    blockHash: '0x2b77e91ddb94c8a37d21dd22c0fdf53481a97517de3146cd526868f106cf5e60',
+    blockNumber: '0x98765',
+    data: '0x12345',
+    type: 'mined'
+  };
+
+  const log1 = {
+    address: addr1,
+    topics: [topic1],
+    ...partialLog
+  };
+
+  const log2 = {
+    address: addr2,
+    topics: [topic1, topic2, topic3],
+    ...partialLog
+  };
+
+  const log3 = {
+    address: addr3,
+    topics: [topic3],
+    ...partialLog
+  };
+
+  it('when no filter', () => {
+    expect(filterLog(log1, {})).to.equal(true);
+    expect(filterLog(log2, {})).to.equal(true);
+  });
+
+  it('filter by address', () => {
+    expect(filterLog(log1, { address: addr1 })).to.equal(true);
+    expect(filterLog(log1, { address: [addr1] })).to.equal(true);
+    expect(filterLog(log1, { address: [addr2, addr1] })).to.equal(true);
+
+    expect(filterLog(log3, { address: addr1 })).to.equal(false);
+    expect(filterLog(log3, { address: [addr1] })).to.equal(false);
+    expect(filterLog(log3, { address: [addr2, addr1] })).to.equal(false);
+  });
+
+  it('filter by topics', () => {
+    expect(filterLog(log1, { topics: [topic1] })).to.equal(true);
+    expect(filterLog(log1, { topics: [topic1, topic2] })).to.equal(true);
+    expect(filterLog(log1, { topics: [null, [topic1], [topic2], null] })).to.equal(true);
+
+    expect(filterLog(log2, { topics: [topic1] })).to.equal(false);
+    expect(filterLog(log2, { topics: [topic1, topic2] })).to.equal(false);
+    expect(filterLog(log2, { topics: [null, [topic1], [topic2], null] })).to.equal(false);
+
+    expect(filterLog(log3, { topics: [topic1] })).to.equal(false);
+    expect(filterLog(log3, { topics: [topic1, topic2] })).to.equal(false);
+    expect(filterLog(log3, { topics: [null, [topic1], [topic2], null] })).to.equal(false);
+  });
+
+  it('filter by topics and logs', () => {
+    // addr1
+    expect(filterLog(log1, { address: addr1, topics: [topic1] })).to.equal(true);
+    expect(filterLog(log1, { address: addr1, topics: [topic1, topic3] })).to.equal(true);
+    expect(filterLog(log1, { address: addr1, topics: [null, [topic1], [topic2], null] })).to.equal(true);
+
+    expect(filterLog(log1, { address: addr2, topics: [topic1] })).to.equal(false);
+    expect(filterLog(log1, { address: addr2, topics: [topic1, topic3] })).to.equal(false);
+    expect(filterLog(log1, { address: addr2, topics: [null, [topic1], [topic2], null] })).to.equal(false);
+    expect(filterLog(log1, { address: addr1, topics: [topic2] })).to.equal(false);
+    expect(filterLog(log1, { address: addr1, topics: [null, [topic2], [topic3], null] })).to.equal(false);
+
+    // addr2
+    expect(filterLog(log2, { address: addr2, topics: [topic1, topic2, topic3] })).to.equal(true);
+
+    expect(filterLog(log2, { address: addr2, topics: [topic1, topic2] })).to.equal(false);
+    expect(filterLog(log2, { address: addr1, topics: [topic1, topic2, topic3] })).to.equal(false);
+  });
+});
+
+describe('toHex', () => {
+  it('return correct hex string', () => {
+    expect(toHex(3)).to.equal('0x3');
+    expect(toHex(18)).to.equal('0x12');
+  });
+});

--- a/eth-providers/src/__tests__/utils.test.ts
+++ b/eth-providers/src/__tests__/utils.test.ts
@@ -64,9 +64,9 @@ describe('filterLog', () => {
     expect(filterLog(log1, { topics: [topic1, topic2.toLowerCase()] })).to.equal(true);
     expect(filterLog(log1, { topics: [null, [topic1.toUpperCase()], [topic2.toLowerCase()], null] })).to.equal(true);
 
-    expect(filterLog(log2, { topics: [topic1] })).to.equal(false);
-    expect(filterLog(log2, { topics: [topic1, topic2] })).to.equal(false);
-    expect(filterLog(log2, { topics: [null, [topic1], [topic2], null] })).to.equal(false);
+    expect(filterLog(log2, { topics: [topic1] })).to.equal(true);
+    expect(filterLog(log2, { topics: [topic1, topic2] })).to.equal(true);
+    expect(filterLog(log2, { topics: [null, [topic1], [topic2], null] })).to.equal(true);
 
     expect(filterLog(log3, { topics: [topic1] })).to.equal(false);
     expect(filterLog(log3, { topics: [topic1, topic2] })).to.equal(false);
@@ -86,11 +86,8 @@ describe('filterLog', () => {
     expect(filterLog(log1, { address: addr1, topics: [null, [topic2], [topic3], null] })).to.equal(false);
 
     // addr2
-    expect(filterLog(log2, { address: addr2.toLowerCase(), topics: [topic1, topic2.toUpperCase(), topic3] })).to.equal(
-      true
-    );
-
-    expect(filterLog(log2, { address: addr2, topics: [topic1, topic2] })).to.equal(false);
+    expect(filterLog(log2, { address: addr2.toLowerCase(), topics: [topic1, topic2.toUpperCase()] })).to.equal(true);
+    expect(filterLog(log2, { address: addr2, topics: [topic2] })).to.equal(true);
     expect(filterLog(log2, { address: addr1, topics: [topic1, topic2, topic3] })).to.equal(false);
   });
 });

--- a/eth-providers/src/__tests__/utils.test.ts
+++ b/eth-providers/src/__tests__/utils.test.ts
@@ -2,13 +2,13 @@ import { expect } from 'chai';
 import { toHex, filterLog } from '../utils';
 
 describe('filterLog', () => {
-  const topic1 = '0x1111111111111111111111111111111111111111111111111111111111111111';
-  const topic2 = '0x2222222222222222222222222222222222222222222222222222222222222222';
-  const topic3 = '0x3333333333333333333333333333333333333333333333333333333333333333';
+  const topic1 = '0x11111111111111111111111111111111111111111111111111111111111111aA';
+  const topic2 = '0x22222222222222222222222222222222222222222222222222222222222222bB';
+  const topic3 = '0x33333333333333333333333333333333333333333333333333333333333333cC';
 
-  const addr1 = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-  const addr2 = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
-  const addr3 = '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+  const addr1 = '0xAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const addr2 = '0xBbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const addr3 = '0xCccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
 
   const partialLog = {
     logIndex: '0x0',
@@ -47,6 +47,8 @@ describe('filterLog', () => {
     expect(filterLog(log1, { address: addr1 })).to.equal(true);
     expect(filterLog(log1, { address: [addr1] })).to.equal(true);
     expect(filterLog(log1, { address: [addr2, addr1] })).to.equal(true);
+    expect(filterLog(log1, { address: addr1.toUpperCase() })).to.equal(true);
+    expect(filterLog(log1, { address: [addr2.toLowerCase(), addr1] })).to.equal(true);
 
     expect(filterLog(log3, { address: addr1 })).to.equal(false);
     expect(filterLog(log3, { address: [addr1] })).to.equal(false);
@@ -57,6 +59,10 @@ describe('filterLog', () => {
     expect(filterLog(log1, { topics: [topic1] })).to.equal(true);
     expect(filterLog(log1, { topics: [topic1, topic2] })).to.equal(true);
     expect(filterLog(log1, { topics: [null, [topic1], [topic2], null] })).to.equal(true);
+
+    expect(filterLog(log1, { topics: [topic1.toUpperCase()] })).to.equal(true);
+    expect(filterLog(log1, { topics: [topic1, topic2.toLowerCase()] })).to.equal(true);
+    expect(filterLog(log1, { topics: [null, [topic1.toUpperCase()], [topic2.toLowerCase()], null] })).to.equal(true);
 
     expect(filterLog(log2, { topics: [topic1] })).to.equal(false);
     expect(filterLog(log2, { topics: [topic1, topic2] })).to.equal(false);
@@ -70,8 +76,8 @@ describe('filterLog', () => {
   it('filter by topics and logs', () => {
     // addr1
     expect(filterLog(log1, { address: addr1, topics: [topic1] })).to.equal(true);
-    expect(filterLog(log1, { address: addr1, topics: [topic1, topic3] })).to.equal(true);
-    expect(filterLog(log1, { address: addr1, topics: [null, [topic1], [topic2], null] })).to.equal(true);
+    expect(filterLog(log1, { address: addr1.toUpperCase(), topics: [topic1, topic3.toLowerCase()] })).to.equal(true);
+    expect(filterLog(log1, { address: addr1, topics: [null, [topic1.toUpperCase()], [topic2], null] })).to.equal(true);
 
     expect(filterLog(log1, { address: addr2, topics: [topic1] })).to.equal(false);
     expect(filterLog(log1, { address: addr2, topics: [topic1, topic3] })).to.equal(false);
@@ -80,7 +86,9 @@ describe('filterLog', () => {
     expect(filterLog(log1, { address: addr1, topics: [null, [topic2], [topic3], null] })).to.equal(false);
 
     // addr2
-    expect(filterLog(log2, { address: addr2, topics: [topic1, topic2, topic3] })).to.equal(true);
+    expect(filterLog(log2, { address: addr2.toLowerCase(), topics: [topic1, topic2.toUpperCase(), topic3] })).to.equal(
+      true
+    );
 
     expect(filterLog(log2, { address: addr2, topics: [topic1, topic2] })).to.equal(false);
     expect(filterLog(log2, { address: addr1, topics: [topic1, topic2, topic3] })).to.equal(false);

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -159,6 +159,12 @@ const NEW_LOGS = 'logs';
 const ALL_EVENTS = [NEW_HEADS, NEW_LOGS];
 
 const DUMMY_ADDRESS = '0x1111111111333333333355555555558888888888';
+const DUMMY_LOGS_BLOOM =
+  '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+const DUMMY_V = '0x25';
+const DUMMY_R = '0x1b5e176d927f8e9ab405058b2d2457392da3e20f328b16ddabcebc33eaac5fea';
+const DUMMY_S = '0x4ba69724e8f69de52f0125ad8b3c5c2cef33019bac3249e2c0a2192766d1721c';
+const EMTPY_UNCLE_HASH = '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347';
 
 export abstract class BaseProvider extends AbstractProvider {
   readonly _api?: ApiPromise;
@@ -201,10 +207,9 @@ export abstract class BaseProvider extends AbstractProvider {
             gasUsed: `0x${block.gasUsed.toNumber()}`,
             miner: block.miner === '' ? DUMMY_ADDRESS : block.miner,
             author: block.author === '' ? DUMMY_ADDRESS : block.author,
-            sha3Uncles: header.parentHash, // TODO: correct value?
+            sha3Uncles: EMTPY_UNCLE_HASH,
             receiptsRoot: block.transactionsRoot, // TODO: correct value?
-            logsBloom:
-              '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' // TODO: ???
+            logsBloom: DUMMY_LOGS_BLOOM // TODO: ???
           })
         );
       }
@@ -354,7 +359,7 @@ export abstract class BaseProvider extends AbstractProvider {
     const deafultNonce = this.api.registry.createType('u64', 0);
     const deafultMixHash = this.api.registry.createType('u256', 0);
 
-    const author = headerExtended.author ? await this.getEvmAddress(headerExtended.author.toString()) : EMPTY_STRING;
+    const author = headerExtended.author ? await this.getEvmAddress(headerExtended.author.toString()) : DUMMY_ADDRESS;
 
     const evmExtrinsicIndexes = getEvmExtrinsicIndexes(events);
 
@@ -390,6 +395,12 @@ export abstract class BaseProvider extends AbstractProvider {
 
         // @TODO Missing data
         return {
+          gasPrice: '0x1', // TODO: get correct value
+          gas: '0x1', // TODO: get correct value
+          input: '', // TODO: get correct value
+          v: DUMMY_V,
+          r: DUMMY_R,
+          s: DUMMY_S,
           blockHash,
           blockNumber,
           transactionIndex,
@@ -419,6 +430,9 @@ export abstract class BaseProvider extends AbstractProvider {
       miner: author,
       author: author,
       extraData: EMPTY_STRING,
+      sha3Uncles: EMTPY_UNCLE_HASH,
+      receiptsRoot: headerExtended.extrinsicsRoot.toHex(), // TODO: ???
+      logsBloom: DUMMY_LOGS_BLOOM, // TODO: ???
 
       transactions
 

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -158,6 +158,8 @@ const NEW_HEADS = 'newHeads';
 const NEW_LOGS = 'logs';
 const ALL_EVENTS = [NEW_HEADS, NEW_LOGS];
 
+const DUMMY_ADDRESS = '0x1111111111333333333355555555558888888888';
+
 export abstract class BaseProvider extends AbstractProvider {
   readonly _api?: ApiPromise;
   readonly formatter: Formatter;
@@ -197,6 +199,8 @@ export abstract class BaseProvider extends AbstractProvider {
             difficulty: toHex(block.difficulty),
             gasLimit: `0x${block.gasLimit.toNumber()}`,
             gasUsed: `0x${block.gasUsed.toNumber()}`,
+            miner: block.miner === '' ? DUMMY_ADDRESS : block.miner,
+            author: block.author === '' ? DUMMY_ADDRESS : block.author,
             sha3Uncles: header.parentHash, // TODO: correct value?
             receiptsRoot: block.transactionsRoot, // TODO: correct value?
             logsBloom:
@@ -220,7 +224,8 @@ export abstract class BaseProvider extends AbstractProvider {
               ...l,
               transactionIndex: toHex(l.transactionIndex),
               blockNumber: toHex(l.blockNumber),
-              logIndex: toHex(l.logIndex)
+              logIndex: toHex(l.logIndex),
+              type: 'mined'
             })
           );
         });

--- a/eth-providers/src/utils/index.ts
+++ b/eth-providers/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './queries';
 export * from './handleTxResponse';
 export * from './sendTx';
 export * from './transactionHelper';
+export * from './utils';

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -6,18 +6,21 @@ export const filterLog = (log: Log, filter: any): boolean => {
 
   if (targetAddr) {
     if (typeof targetAddr === 'string') {
-      if (log.address !== targetAddr) return false;
+      if (log.address.toLowerCase() !== targetAddr.toLowerCase()) return false;
     } else if (Array.isArray(targetAddr)) {
-      if (!targetAddr.includes(log.address)) return false;
+      if (!targetAddr.map((x) => x.toLowerCase()).includes(log.address.toLowerCase())) return false;
     }
   }
 
   if (targetTopics?.length > 0) {
     if (!log.topics?.length) return false;
 
-    const _targetTopics = targetTopics.flat();
+    const _targetTopics = targetTopics
+      .flat()
+      .filter((x) => x)
+      .map((x) => x.toLowerCase());
     for (const t of log.topics) {
-      if (!_targetTopics.includes(t)) return false;
+      if (!_targetTopics.includes(t.toLowerCase())) return false;
     }
   }
 

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -1,0 +1,27 @@
+import { Log } from '@ethersproject/abstract-provider';
+
+// TODO: optimize it to better bloom filter
+export const filterLog = (log: Log, filter: any): boolean => {
+  const { address: targetAddr, topics: targetTopics } = filter;
+
+  if (targetAddr) {
+    if (typeof targetAddr === 'string') {
+      if (log.address !== targetAddr) return false;
+    } else if (Array.isArray(targetAddr)) {
+      if (!targetAddr.includes(log.address)) return false;
+    }
+  }
+
+  if (targetTopics?.length > 0) {
+    if (!log.topics?.length) return false;
+
+    const _targetTopics = targetTopics.flat();
+    for (const t of log.topics) {
+      if (!_targetTopics.includes(t)) return false;
+    }
+  }
+
+  return true;
+};
+
+export const toHex = (x: number): string => `0x${x.toString(16)}`;

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -20,8 +20,10 @@ export const filterLog = (log: Log, filter: any): boolean => {
       .filter((x: any) => x)
       .map((x: string) => x.toLowerCase());
     for (const t of log.topics) {
-      if (!_targetTopics.includes(t.toLowerCase())) return false;
+      if (_targetTopics.includes(t.toLowerCase())) return true;
     }
+
+    return false;
   }
 
   return true;

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -8,7 +8,7 @@ export const filterLog = (log: Log, filter: any): boolean => {
     if (typeof targetAddr === 'string') {
       if (log.address.toLowerCase() !== targetAddr.toLowerCase()) return false;
     } else if (Array.isArray(targetAddr)) {
-      if (!targetAddr.map((x) => x.toLowerCase()).includes(log.address.toLowerCase())) return false;
+      if (!targetAddr.map((x: string) => x.toLowerCase()).includes(log.address.toLowerCase())) return false;
     }
   }
 
@@ -17,8 +17,8 @@ export const filterLog = (log: Log, filter: any): boolean => {
 
     const _targetTopics = targetTopics
       .flat()
-      .filter((x) => x)
-      .map((x) => x.toLowerCase());
+      .filter((x: any) => x)
+      .map((x: string) => x.toLowerCase());
     for (const t of log.topics) {
       if (!_targetTopics.includes(t.toLowerCase())) return false;
     }

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -29,10 +29,10 @@ export class Eip1193Bridge extends EventEmitter {
     return this.isMethodValid(method) && method in this.#impl;
   }
 
-  async send(method: string, params: any[] = []): Promise<any> {
+  async send(method: string, params: any[] = [], cb?: any): Promise<any> {
     if (this.isMethodImplemented(method)) {
       // isMethodImplemented ensuress this cannot be used to access other unrelated methods
-      return this.#impl[method](params);
+      return this.#impl[method](params, cb);
     }
 
     throw new MethodNotFound('Method not available', `The method ${method} is not available.`);
@@ -394,5 +394,10 @@ class Eip1193BridgeImpl {
   async eth_getLogs(params: any[]): Promise<Log[]> {
     validate([{ type: 'object' }], params);
     return this.#provider.getLogs(params[0]);
+  }
+
+  async eth_subscribe(params: any[], cb: any): Promise<any> {
+    validate([{ type: 'eventName' }, { type: 'object?' }], params);
+    return this.#provider.on(params[0], cb);
   }
 }

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -400,4 +400,9 @@ class Eip1193BridgeImpl {
     validate([{ type: 'eventName' }, { type: 'object?' }], params);
     return this.#provider.addEventListener(params[0], cb, params[1]);
   }
+
+  async eth_unsubscribe(params: any[], cb: any): Promise<any> {
+    validate([{ type: 'address' }], params);
+    return this.#provider.removeEventListener(params[0]);
+  }
 }

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -398,6 +398,6 @@ class Eip1193BridgeImpl {
 
   async eth_subscribe(params: any[], cb: any): Promise<any> {
     validate([{ type: 'eventName' }, { type: 'object?' }], params);
-    return this.#provider.on(params[0], cb);
+    return this.#provider.addEventListener(params[0], cb, params[1]);
   }
 }

--- a/eth-rpc-adapter/src/router.ts
+++ b/eth-rpc-adapter/src/router.ts
@@ -11,9 +11,9 @@ export class Router {
     this.#bridge = bridge;
   }
 
-  public async call(methodName: string, params: unknown[]): Promise<Partial<JSONRPCResponse>> {
+  public async call(methodName: string, params: unknown[], cb?: any): Promise<Partial<JSONRPCResponse>> {
     try {
-      return { result: await this.#bridge.send(methodName, params) };
+      return { result: await this.#bridge.send(methodName, params, cb) };
     } catch (err: any) {
       if (JSONRPCError.isJSONRPCError(err)) {
         return { error: { code: err.code, message: err.message, data: err.data } };

--- a/eth-rpc-adapter/src/transports/server-transport.ts
+++ b/eth-rpc-adapter/src/transports/server-transport.ts
@@ -18,7 +18,7 @@ export abstract class ServerTransport {
     throw new Error('Transport missing start implementation');
   }
 
-  protected async routerHandler({ id, method, params }: JSONRPCRequest): Promise<JSONRPCResponse> {
+  protected async routerHandler({ id, method, params }: JSONRPCRequest, cb?: any): Promise<JSONRPCResponse> {
     if (id === null || id === undefined) {
       const error = new InvalidRequest();
       return {
@@ -57,7 +57,7 @@ export abstract class ServerTransport {
     } else {
       res = {
         ...res,
-        ...(await routerForMethod.call(method, params as any))
+        ...(await routerForMethod.call(method, params as any, cb))
       };
     }
 

--- a/eth-rpc-adapter/src/transports/websocket.ts
+++ b/eth-rpc-adapter/src/transports/websocket.ts
@@ -76,7 +76,7 @@ export default class WebSocketServerTransport extends ServerTransport {
       );
 
     let result = null;
-    logger.debug(req, 'incoming request');
+    logger.debug(req, 'WS incoming request');
     if (req instanceof Array) {
       result = await Promise.all(req.map((r: JSONRPCRequest) => super.routerHandler(r, respondWith)));
     } else {

--- a/eth-rpc-adapter/src/transports/websocket.ts
+++ b/eth-rpc-adapter/src/transports/websocket.ts
@@ -65,13 +65,13 @@ export default class WebSocketServerTransport extends ServerTransport {
     this.server.close();
   }
 
-  private async webSocketRouterHandler(req: any, respondWith: any) {
+  private async webSocketRouterHandler(req: any, respondWith: any): Promise<void> {
     let result = null;
-    logger.debug(req.body, 'incoming request');
+    logger.debug(req, 'incoming request');
     if (req instanceof Array) {
-      result = await Promise.all(req.map((r: JSONRPCRequest) => super.routerHandler(r)));
+      result = await Promise.all(req.map((r: JSONRPCRequest) => super.routerHandler(r, respondWith)));
     } else {
-      result = await super.routerHandler(req);
+      result = await super.routerHandler(req, respondWith);
     }
     logger.debug(result, 'request completed');
     respondWith(JSON.stringify(result));

--- a/eth-rpc-adapter/src/transports/websocket.ts
+++ b/eth-rpc-adapter/src/transports/websocket.ts
@@ -65,7 +65,16 @@ export default class WebSocketServerTransport extends ServerTransport {
     this.server.close();
   }
 
-  private async webSocketRouterHandler(req: any, respondWith: any): Promise<void> {
+  private async webSocketRouterHandler(req: any, wsSend: any): Promise<void> {
+    const respondWith = (data: any): void =>
+      wsSend(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'eth_subscription',
+          params: data
+        })
+      );
+
     let result = null;
     logger.debug(req, 'incoming request');
     if (req instanceof Array) {
@@ -74,6 +83,6 @@ export default class WebSocketServerTransport extends ServerTransport {
       result = await super.routerHandler(req, respondWith);
     }
     logger.debug(result, 'request completed');
-    respondWith(JSON.stringify(result));
+    wsSend(JSON.stringify(result));
   }
 }

--- a/eth-rpc-adapter/src/validate.ts
+++ b/eth-rpc-adapter/src/validate.ts
@@ -11,9 +11,17 @@ export type Schema = {
     | 'position'
     | 'transactionData'
     | 'object'
+    | 'object?'
     | 'message'
-    | 'hexNumber';
+    | 'hexNumber'
+    | 'eventName';
 }[];
+
+export const validateEventName = (value: any) => {
+  if (!['newHeads', 'logs', 'newPendingTransactions'].includes(value)) {
+    throw new Error('expected type eventName');
+  }
+};
 
 export const validateString = (value: any) => {
   if (typeof value !== 'string') {
@@ -140,12 +148,20 @@ export const validate = (schema: Schema, data: unknown[]) => {
           validateObject(data[i]);
           break;
         }
+        case 'object?': {
+          data[i] && validateObject(data[i]);
+          break;
+        }
         case 'message': {
           validateString(data[i]);
           break;
         }
         case 'hexNumber': {
           validateHexNumber(data[i] as any);
+          break;
+        }
+        case 'eventName': {
+          validateEventName(data[i] as any);
           break;
         }
         default:

--- a/eth-rpc-adapter/src/validate.ts
+++ b/eth-rpc-adapter/src/validate.ts
@@ -106,7 +106,7 @@ export const validate = (schema: Schema, data: unknown[]) => {
   }
 
   for (let i = 0; i < schema.length; i++) {
-    if (data[i] === undefined) {
+    if (data[i] === undefined && !schema[i].type.endsWith('?')) {
       throw new InvalidParams(`missing value for required argument ${i}`);
     }
 


### PR DESCRIPTION
## Change
implemented `eth_subscribe` method, currently it only support `newHeads` and `logs` params.

## Test
- unit tested log filter function
- manually tested subscribe and unsubscribe, and they can send back logs/heads info from websocket