### PR TITLE
Bump dockerized Mandala to latest version

### DIFF
--- a/evm-subql/docker-compose.yml
+++ b/evm-subql/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mandala-node:
-    image: acala/mandala-node:01a2dea6
+    image: acala/mandala-node:e361c534
     ports:
       - 9944:9944
     command:


### PR DESCRIPTION
Current latest version of acala/mandala-node Docker image is e361c534,
so it has been bumped in order to enable the latest features in the
local development networks.