### PR TITLE
support pending tag for `eth_getCode`

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -545,6 +545,8 @@ export abstract class BaseProvider extends AbstractProvider {
     await this.getNetwork();
     await this._ensureSafeModeFinalization(blockTag);
 
+    if ((await blockTag) === 'pending') return '0x';
+
     const { address, blockHash } = await resolveProperties({
       address: this._getAddress(addressOrName),
       blockHash: this._getBlockHash(blockTag)


### PR DESCRIPTION
## Change
The only pending info we have access to is the pending extrinsics, which has the input data for contract creation. However, getCode needs the compiled bytecodes for EVM, and there is no easy way for us to compute
```
input data => compiled bytecodes
```
unless we simulate the EVM running in rpc adaptor, which is an overkill. In most cases `eth_getCode(addr, 'latest')` would be enough, so we decided to return empty for now for `eth_getCode(addr, 'pending')`, and will find other workaround if this call is absolutely needed.

fix #272 

## Test
added some basic tests for `eth_getCode`