### PR TITLE
Safe Mode v2

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -116,6 +116,8 @@ importers:
       graphql: ~16.0.1
       graphql-request: ~3.6.1
       mocha: ~9.1.3
+      sinon: ~13.0.1
+      sinon-chai: ~3.7.0
       ts-node: ~10.3.0
       typescript: ~4.4.4
     dependencies:
@@ -158,6 +160,8 @@ importers:
       chai-as-promised: 7.1.1_chai@4.3.4
       eslint: 7.32.0
       mocha: 9.1.3
+      sinon: 13.0.1
+      sinon-chai: 3.7.0_chai@4.3.4+sinon@13.0.1
       ts-node: 10.3.1_typescript@4.4.4
       typescript: 4.4.4
 
@@ -325,7 +329,7 @@ importers:
       hardhat: 2.8.0
     devDependencies:
       '@acala-network/contracts': 4.0.2
-      '@acala-network/eth-providers': 2.1.11
+      '@acala-network/eth-providers': 2.2.2
       '@nomiclabs/hardhat-ethers': 2.0.3_ethers@5.5.2+hardhat@2.8.0
       '@nomiclabs/hardhat-waffle': 2.0.1_b5edb2070812aa32af4b3ffe4f4a52ce
       '@openzeppelin/contracts': 4.4.2
@@ -348,7 +352,7 @@ importers:
     dependencies:
       hardhat: 2.8.0
     devDependencies:
-      '@acala-network/eth-providers': 2.1.11
+      '@acala-network/eth-providers': 2.2.2
       '@nomiclabs/hardhat-ethers': 2.0.3_ethers@5.5.2+hardhat@2.8.0
       '@nomiclabs/hardhat-waffle': 2.0.1_b5edb2070812aa32af4b3ffe4f4a52ce
       '@openzeppelin/contracts': 4.4.2
@@ -370,7 +374,7 @@ importers:
     dependencies:
       hardhat: 2.8.0
     devDependencies:
-      '@acala-network/eth-providers': 2.1.11
+      '@acala-network/eth-providers': 2.2.2
       '@nomiclabs/hardhat-ethers': 2.0.3_ethers@5.5.2+hardhat@2.8.0
       '@nomiclabs/hardhat-waffle': 2.0.1_b5edb2070812aa32af4b3ffe4f4a52ce
       '@polkadot/api': 7.10.1
@@ -391,7 +395,7 @@ importers:
     dependencies:
       hardhat: 2.8.0
     devDependencies:
-      '@acala-network/eth-providers': 2.1.11
+      '@acala-network/eth-providers': 2.2.2
       '@nomiclabs/hardhat-ethers': 2.0.3_ethers@5.5.2+hardhat@2.8.0
       '@nomiclabs/hardhat-waffle': 2.0.1_b5edb2070812aa32af4b3ffe4f4a52ce
       '@polkadot/api': 7.10.1
@@ -436,7 +440,7 @@ importers:
     dependencies:
       hardhat: 2.8.0
     devDependencies:
-      '@acala-network/eth-providers': 2.1.11
+      '@acala-network/eth-providers': 2.2.2
       '@nomiclabs/hardhat-ethers': 2.0.3_ethers@5.5.2+hardhat@2.8.0
       '@nomiclabs/hardhat-waffle': 2.0.1_b5edb2070812aa32af4b3ffe4f4a52ce
       '@openzeppelin/contracts': 4.4.2
@@ -1051,38 +1055,6 @@ packages:
   /@acala-network/contracts/4.0.2:
     resolution: {integrity: sha512-IYYRbZwvA/bRfp/nV6oiPDkR68eyxYY+jevby+mDHIt4vrlMDgPjKNhLrPnVkGSymOYuosZjeO4jMEhXtisL4g==}
 
-  /@acala-network/eth-providers/2.1.11:
-    resolution: {integrity: sha512-BLyWTLVlAtdWNmufI8TzvgXTgYZ0vqq9H4eQyexPTPsa5BlkSTm7ZUahrYzeKmrtmgZEYIax3fqNC66wxFx98w==}
-    dependencies:
-      '@acala-network/api': 3.0.3-16_@polkadot+types@6.11.1
-      '@acala-network/eth-transactions': 2.1.11
-      '@acala-network/types': 3.0.3-16
-      '@ethersproject/abstract-provider': 5.5.1
-      '@ethersproject/bignumber': 5.5.0
-      '@ethersproject/bytes': 5.5.0
-      '@ethersproject/logger': 5.5.0
-      '@ethersproject/networks': 5.5.1
-      '@ethersproject/properties': 5.5.0
-      '@ethersproject/providers': 5.5.1
-      '@ethersproject/transactions': 5.5.0
-      '@graphql-codegen/typescript': 2.3.0_graphql@16.0.1
-      '@polkadot/api': 6.11.1
-      '@polkadot/api-derive': 6.11.1
-      '@polkadot/types': 6.11.1
-      '@polkadot/util': 8.1.2
-      '@polkadot/util-crypto': 8.1.2
-      bn.js: 4.12.0
-      dotenv: 10.0.0
-      ethers: 5.4.7
-      graphql: 16.0.1
-      graphql-request: 3.6.1_graphql@16.0.1
-    transitivePeerDependencies:
-      - '@polkadot/typegen'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /@acala-network/eth-providers/2.2.2:
     resolution: {integrity: sha512-DhZuoQR49cFzrV7zUcCt5W5VooBQg6TMh9juRrfnSqZ3Y7LOx97XA/qMqk1x0FVtz/XwZuMTbz/pWq6veeE8AA==}
     dependencies:
@@ -1113,25 +1085,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: false
-
-  /@acala-network/eth-transactions/2.1.11:
-    resolution: {integrity: sha512-usCg3CRzCYLQNBnZoaSVQH7GOBWdc+IuM0EBiNA8IP+ee40Ju5yu8e4qyd2DnR3CbMqDRQtXHvO1p7FaXRvPGw==}
-    dependencies:
-      '@ethersproject/address': 5.5.0
-      '@ethersproject/bignumber': 5.5.0
-      '@ethersproject/bytes': 5.5.0
-      '@ethersproject/constants': 5.5.0
-      '@ethersproject/hash': 5.5.0
-      '@ethersproject/keccak256': 5.5.0
-      '@ethersproject/logger': 5.5.0
-      '@ethersproject/properties': 5.5.0
-      '@ethersproject/rlp': 5.5.0
-      '@ethersproject/signing-key': 5.5.0
-      '@ethersproject/transactions': 5.5.0
-      '@ethersproject/wallet': 5.5.0
-      '@polkadot/util-crypto': 8.1.2
-    dev: true
 
   /@acala-network/eth-transactions/2.2.2:
     resolution: {integrity: sha512-POgZcC0hnJ11cYOKaFFOZuPauB9gYda3LegS8/GJX/4j2ACplR14avqGW13JpeZrcsw2V2bRIiFO2tcdJmvuzA==}
@@ -1149,7 +1102,6 @@ packages:
       '@ethersproject/transactions': 5.5.0
       '@ethersproject/wallet': 5.5.0
       '@polkadot/util-crypto': 8.1.2
-    dev: false
 
   /@acala-network/type-definitions/3.0.3-16:
     resolution: {integrity: sha512-qraf5JapinDQvLxT5H/8HycyYzb+B/e9n7A5cCMXyML2Qe9nbPk7JiH9dVocIB87Z7his/yrUOExqh6L4CShXQ==}
@@ -4071,6 +4023,24 @@ packages:
     resolution: {integrity: sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==}
     dependencies:
       '@sinonjs/commons': 1.8.3
+    dev: true
+
+  /@sinonjs/fake-timers/9.1.0:
+    resolution: {integrity: sha512-M8vapsv9qQupMdzrVzkn5rb9jG7aUTEPAZdMtME2PuBaefksFZVE2C1g4LBRTkF/k3nRDNbDc5tp5NFC1PEYxA==}
+    dependencies:
+      '@sinonjs/commons': 1.8.3
+    dev: true
+
+  /@sinonjs/samsam/6.1.1:
+    resolution: {integrity: sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==}
+    dependencies:
+      '@sinonjs/commons': 1.8.3
+      lodash.get: 4.4.2
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/text-encoding/0.7.1:
+    resolution: {integrity: sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==}
     dev: true
 
   /@solidity-parser/parser/0.14.0:
@@ -11951,6 +11921,10 @@ packages:
       object.assign: 4.1.2
     dev: true
 
+  /just-extend/4.2.1:
+    resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
+    dev: true
+
   /jwa/1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
     dependencies:
@@ -13494,6 +13468,16 @@ packages:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
 
+  /nise/5.1.1:
+    resolution: {integrity: sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==}
+    dependencies:
+      '@sinonjs/commons': 1.8.3
+      '@sinonjs/fake-timers': 9.1.0
+      '@sinonjs/text-encoding': 0.7.1
+      just-extend: 4.2.1
+      path-to-regexp: 1.8.0
+    dev: true
+
   /no-case/2.3.2:
     resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
     dependencies:
@@ -14308,6 +14292,12 @@ packages:
 
   /path-to-regexp/0.1.7:
     resolution: {integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=}
+
+  /path-to-regexp/1.8.0:
+    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
+    dependencies:
+      isarray: 0.0.1
+    dev: true
 
   /path-type/1.1.0:
     resolution: {integrity: sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=}
@@ -15935,6 +15925,27 @@ packages:
       decompress-response: 3.3.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  /sinon-chai/3.7.0_chai@4.3.4+sinon@13.0.1:
+    resolution: {integrity: sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==}
+    peerDependencies:
+      chai: ^4.0.0
+      sinon: '>=4.0.0'
+    dependencies:
+      chai: 4.3.4
+      sinon: 13.0.1
+    dev: true
+
+  /sinon/13.0.1:
+    resolution: {integrity: sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==}
+    dependencies:
+      '@sinonjs/commons': 1.8.3
+      '@sinonjs/fake-timers': 9.1.0
+      '@sinonjs/samsam': 6.1.1
+      diff: 5.0.0
+      nise: 5.1.1
+      supports-color: 7.2.0
+    dev: true
 
   /slash/1.0.0:
     resolution: {integrity: sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=}

--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -56,6 +56,8 @@
     "@ethersproject/contracts": "~5.5.0",
     "@ethersproject/wallet": "~5.5.0",
     "chai-as-promised": "~7.1.1",
-    "@types/chai-as-promised": "~7.1.4"
+    "@types/chai-as-promised": "~7.1.4",
+    "sinon-chai": "~3.7.0",
+    "sinon": "~13.0.1"
   }
 }

--- a/eth-providers/src/__tests__/e2e/safemode.test.ts
+++ b/eth-providers/src/__tests__/e2e/safemode.test.ts
@@ -18,7 +18,7 @@ const newBlock = async (finalize: boolean): Promise<void> => {
   await sleep(100);
 };
 
-describe('query latest tag in safe mode', () => {
+describe('safe mode', () => {
   before(async () => {
     await Promise.all([
       safeProvider.isReady(),
@@ -35,7 +35,7 @@ describe('query latest tag in safe mode', () => {
 
   beforeEach(async () => await newBlock(true));
 
-  it.skip('getBlockNumber', async () => {
+  it('getBlockNumber', async () => {
     // make sure latest finalized block and latest block are even
     const [curBlock, curFinalizedBlock] = await Promise.all([
       provider.getBlockNumber(),
@@ -67,7 +67,7 @@ describe('query latest tag in safe mode', () => {
     expect((await safeProvider._getBlock()).number).to.equal(curBlock.number);
   });
 
-  it.skip('_ensureSafeModeBlockTagFinalization', async () => {
+  it('_ensureSafeModeBlockTagFinalization', async () => {
     // make sure latest finalized block and latest block are even
     const [curBlock, curFinalizedBlock] = await Promise.all([
       provider._getBlock(),
@@ -94,11 +94,11 @@ describe('query latest tag in safe mode', () => {
     expect(await provider._ensureSafeModeBlockTagFinalization('whatever')).to.equal('whatever');
 
     /* --------------------------
-      in safe mode:
-      - "latest" should point to latest finalized block
-      - finalized block / no tag should so nothing and return the same tag
-      - unfinalized block should throw error
-                                                  -------------------------- */
+        in safe mode:
+        - "latest" should point to latest finalized block
+        - finalized block / no tag should so nothing and return the same tag
+        - unfinalized block should throw error
+                                                   -------------------------- */
     expect(await safeProvider._ensureSafeModeBlockTagFinalization(undefined)).to.equal(undefined);
     expect(await safeProvider._ensureSafeModeBlockTagFinalization('latest')).to.equal(safeProvider.latestFinalizedBlockHash);
     expect(await safeProvider._ensureSafeModeBlockTagFinalization('latest')).to.equal(curFinalizedBlock.hash);

--- a/eth-providers/src/__tests__/e2e/safemode.test.ts
+++ b/eth-providers/src/__tests__/e2e/safemode.test.ts
@@ -1,0 +1,161 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import { EvmRpcProvider } from '../../rpc-provider';
+import { sleep } from '../../utils';
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai)
+const { expect } = chai;
+
+const endpoint = process.env.ENDPOINT_URL || 'ws://127.0.0.1:9944';
+const safeProvider = EvmRpcProvider.from(endpoint, { safeMode: true });
+const provider = EvmRpcProvider.from(endpoint, { safeMode: false });
+
+const newBlock = async (finalize: boolean): Promise<void> => {
+  await provider.api.rpc.engine.createBlock(true /* create empty */, finalize);
+  await sleep(100);
+};
+
+describe('query latest tag in safe mode', () => {
+  before(async () => {
+    await Promise.all([
+      safeProvider.isReady(),
+      provider.isReady(),
+    ]);
+  });
+
+  after(async () => {
+    await Promise.all([
+      safeProvider.disconnect(),
+      provider.disconnect(),
+    ]);
+  });
+
+  beforeEach(async () => await newBlock(true));
+
+  it.skip('getBlockNumber', async () => {
+    // make sure latest finalized block and latest block are even
+    const [curBlock, curFinalizedBlock] = await Promise.all([
+      provider.getBlockNumber(),
+      safeProvider.getBlockNumber(),
+    ]);
+    expect(curBlock).to.equal(curFinalizedBlock);
+    expect(curBlock).to.equal(safeProvider.latestFinalizedBlockHash);
+
+    // real test
+    await newBlock(false);
+    expect(await provider.getBlockNumber()).to.equal(curBlock + 1);
+    expect(await provider.getBlockNumber('latest')).to.equal(curBlock + 1);
+    expect(await safeProvider.getBlockNumber()).to.equal(curBlock);
+    expect(await safeProvider.getBlockNumber('latest')).to.equal(curBlock);
+  });
+
+  it('_getBlock', async () => {
+    // make sure latest finalized block and latest block are even
+    const [curBlock, curFinalizedBlock] = await Promise.all([
+      provider._getBlock(),
+      safeProvider._getBlock(),
+    ]);
+    expect(curBlock.hash).to.equal(curFinalizedBlock.hash);
+    expect(curBlock.hash).to.equal(safeProvider.latestFinalizedBlockHash);
+
+    // real test
+    await newBlock(false);
+    expect((await provider._getBlock()).number).to.equal(curBlock.number + 1);
+    expect((await safeProvider._getBlock()).number).to.equal(curBlock.number);
+  });
+
+  it.skip('_ensureSafeModeBlockTagFinalization', async () => {
+    // make sure latest finalized block and latest block are even
+    const [curBlock, curFinalizedBlock] = await Promise.all([
+      provider._getBlock(),
+      safeProvider._getBlock(),
+    ]);
+    expect(curBlock.hash).to.equal(curFinalizedBlock.hash);
+    expect(curBlock.hash).to.equal(safeProvider.latestFinalizedBlockHash);
+
+    // make sure next block is not finalized
+    await newBlock(false);
+    const [nextBlock, nextFinalizedBlock] = await Promise.all([
+      provider._getBlock(),
+      safeProvider._getBlock(),
+    ]);
+    expect(curBlock.hash).to.not.equal(nextBlock.hash);
+    expect(curFinalizedBlock.hash).to.equal(nextFinalizedBlock.hash);
+    expect(curFinalizedBlock.hash).to.equal(curBlock.hash);
+
+    // in normal mode this should do nothing and just return the same tag
+    expect(await provider._ensureSafeModeBlockTagFinalization(undefined)).to.equal(undefined);
+    expect(await provider._ensureSafeModeBlockTagFinalization('latest')).to.equal('latest');
+    expect(await provider._ensureSafeModeBlockTagFinalization('0x1234567')).to.equal('0x1234567');
+    expect(await provider._ensureSafeModeBlockTagFinalization(123)).to.equal(123);
+    expect(await provider._ensureSafeModeBlockTagFinalization('whatever')).to.equal('whatever');
+
+    /* --------------------------
+      in safe mode:
+      - "latest" should point to latest finalized block
+      - finalized block / no tag should so nothing and return the same tag
+      - unfinalized block should throw error
+                                                  -------------------------- */
+    expect(await safeProvider._ensureSafeModeBlockTagFinalization(undefined)).to.equal(undefined);
+    expect(await safeProvider._ensureSafeModeBlockTagFinalization('latest')).to.equal(safeProvider.latestFinalizedBlockHash);
+    expect(await safeProvider._ensureSafeModeBlockTagFinalization('latest')).to.equal(curFinalizedBlock.hash);
+    expect(await safeProvider._ensureSafeModeBlockTagFinalization(curFinalizedBlock.hash)).to.equal(curFinalizedBlock.hash);
+
+    for (let i = 1; i < curFinalizedBlock.number; i++) {
+      const hash = await provider._getBlockHash(i);
+      expect(await safeProvider._ensureSafeModeBlockTagFinalization(i)).to.equal(i);
+      expect(await safeProvider._ensureSafeModeBlockTagFinalization(hash)).to.equal(hash);
+    }
+
+    await expect(
+      safeProvider._ensureSafeModeBlockTagFinalization(nextBlock.hash)
+    ).to.be.rejectedWith('SAFE MODE ERROR: target block is not finalized');
+  });
+
+  it('subscribe', async () => {
+    // setup
+    const cb = sinon.spy();
+    const safeCb = sinon.spy();
+    const sub = provider.addEventListener('newHeads', cb, {});
+    const safeSub = safeProvider.addEventListener('newHeads', safeCb, {});
+
+    // new finalized block
+    await newBlock(true);
+    let curHash = (await provider._getBlock()).hash;
+
+    expect(cb).to.have.been.calledWithMatch({
+      subscription: sub,
+      result: {
+        hash: curHash,
+      }
+    });
+
+    expect(safeCb).to.have.been.calledWithMatch({
+      subscription: safeSub,
+      result: {
+        hash: curHash,
+      }
+    });
+
+    // new unfinalized block
+    await newBlock(false);
+    curHash = (await provider._getBlock()).hash;
+
+    expect(cb).to.have.been.calledWithMatch({
+      subscription: sub,
+      result: {
+        hash: curHash,
+      }
+    });
+
+    expect(safeCb).to.have.not.been.calledWithMatch({
+      subscription: safeSub,
+      result: {
+        hash: curHash,
+      }
+    });
+  });
+});

--- a/eth-providers/src/__tests__/e2e/safemode.test.ts
+++ b/eth-providers/src/__tests__/e2e/safemode.test.ts
@@ -3,7 +3,6 @@ import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import { EvmRpcProvider } from '../../rpc-provider';
-import { sleep } from '../../utils';
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai)

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1282,12 +1282,13 @@ export abstract class BaseProvider extends AbstractProvider {
     );
   };
 
-  _ensureSafeModeBlockTagFinalization = async (blockTag: BlockTagish): Promise<BlockTagish> => {
-    if (!this.safeMode || !blockTag) return blockTag;
+  _ensureSafeModeBlockTagFinalization = async (_blockTag: BlockTagish): Promise<BlockTagish> => {
+    if (!this.safeMode || !_blockTag) return _blockTag;
 
+    const blockTag = await _blockTag;
     if (blockTag === 'latest') return this.latestFinalizedBlockHash;
 
-    const isBlockFinalized = await this._isBlockFinalized(await blockTag);
+    const isBlockFinalized = await this._isBlockFinalized(blockTag);
 
     return isBlockFinalized
       ? blockTag

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1214,7 +1214,7 @@ export abstract class BaseProvider extends AbstractProvider {
   };
 
   _getBlockHash = async (_blockTag?: BlockTag | Promise<BlockTag>): Promise<string> => {
-    const blockTag = await _blockTag || 'latest';
+    const blockTag = (await _blockTag) || 'latest';
 
     switch (blockTag) {
       case 'pending': {

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -157,6 +157,8 @@ export interface EventListeners {
   [name: string]: EventListener[];
 }
 
+export type BlockTagish = BlockTag | Promise<BlockTag> | undefined;
+
 const NEW_HEADS = 'newHeads';
 const NEW_LOGS = 'logs';
 const ALL_EVENTS = [NEW_HEADS, NEW_LOGS];
@@ -177,19 +179,21 @@ export abstract class BaseProvider extends AbstractProvider {
 
   _network?: Promise<Network>;
   _cache?: UnfinalizedBlockCache;
+  latestFinalizedBlockHash: string | undefined;
 
   constructor(safeMode: boolean = false) {
     super();
     this.formatter = new Formatter();
     this._listeners = {};
     this.safeMode = safeMode;
+    this.latestFinalizedBlockHash = undefined;
 
     logger.info(`safe mode: ${safeMode}`);
     safeMode && logger.warn(`
-      ----------------------------- WARNING ---------------------------------
-      SafeMode is enabled, unfinalized blocks behave like they don't exist!
-      To go back to normal mode, set SAFE_MODE=0
-      -----------------------------------------------------------------------
+      ----------------------------- WARNING ----------------------------
+      SafeMode is ON, and RPCs behave very differently than usual world!
+                  To go back to normal mode, set SAFE_MODE=0
+      ------------------------------------------------------------------
     `);
   }
 
@@ -267,7 +271,16 @@ export abstract class BaseProvider extends AbstractProvider {
     }) as unknown as void;
 
     this.api.rpc.chain.subscribeFinalizedHeads(async (header: Header) => {
-      this._cache!.handleFinalizedBlock(header.number.toNumber());
+      const blockNumber = header.number.toNumber();
+
+      // safe mode related
+      if (this.safeMode) {
+        const blockHash = (await this.api.rpc.chain.getBlockHash(blockNumber)).toHex();
+        this.latestFinalizedBlockHash = blockHash;
+      }
+
+      // cache related
+      this._cache!.handleFinalizedBlock(blockNumber);
     }) as unknown as void;
   };
 
@@ -358,11 +371,11 @@ export abstract class BaseProvider extends AbstractProvider {
   };
 
   _getBlock = async (
-    blockTag: BlockTag | Promise<BlockTag>,
+    _blockTag: BlockTag | Promise<BlockTag>,
     full?: boolean | Promise<boolean>
   ): Promise<RichBlock | BlockWithTransactions> => {
     await this.getNetwork();
-    await this._ensureSafeModeFinalization(blockTag);
+    const blockTag = await this._ensureSafeModeBlockTagFinalization(_blockTag);
 
     const { fullTx, header } = await resolveProperties({
       header: this._getBlockHeader(blockTag),
@@ -477,10 +490,10 @@ export abstract class BaseProvider extends AbstractProvider {
   // @TODO free
   getBalance = async (
     addressOrName: string | Promise<string>,
-    blockTag?: BlockTag | Promise<BlockTag>
+    _blockTag?: BlockTag | Promise<BlockTag>
   ): Promise<BigNumber> => {
     await this.getNetwork();
-    await this._ensureSafeModeFinalization(blockTag);
+    const blockTag = await this._ensureSafeModeBlockTagFinalization(_blockTag);
 
     const { address, blockHash } = await resolveProperties({
       address: this._getAddress(addressOrName),
@@ -540,10 +553,10 @@ export abstract class BaseProvider extends AbstractProvider {
 
   getCode = async (
     addressOrName: string | Promise<string>,
-    blockTag?: BlockTag | Promise<BlockTag>
+    _blockTag?: BlockTag | Promise<BlockTag>
   ): Promise<string> => {
     await this.getNetwork();
-    await this._ensureSafeModeFinalization(blockTag);
+    const blockTag = await this._ensureSafeModeBlockTagFinalization(_blockTag);
 
     if ((await blockTag) === 'pending') return '0x';
 
@@ -569,10 +582,10 @@ export abstract class BaseProvider extends AbstractProvider {
 
   call = async (
     transaction: Deferrable<TransactionRequest>,
-    blockTag?: BlockTag | Promise<BlockTag>
+    _blockTag?: BlockTag | Promise<BlockTag>
   ): Promise<string> => {
     await this.getNetwork();
-    await this._ensureSafeModeFinalization(blockTag); // TODO: do we need this check for call?
+    const blockTag = await this._ensureSafeModeBlockTagFinalization(_blockTag);
 
     const resolved = await resolveProperties({
       transaction: this._getTransactionRequest(transaction),
@@ -599,10 +612,10 @@ export abstract class BaseProvider extends AbstractProvider {
   getStorageAt = async (
     addressOrName: string | Promise<string>,
     position: BigNumberish | Promise<BigNumberish>,
-    blockTag?: BlockTag | Promise<BlockTag>
+    _blockTag?: BlockTag | Promise<BlockTag>
   ): Promise<string> => {
     await this.getNetwork();
-    await this._ensureSafeModeFinalization(blockTag);
+    const blockTag = await this._ensureSafeModeBlockTagFinalization(_blockTag);
 
     // @TODO resolvedPosition
     const { address, blockHash, resolvedPosition } = await resolveProperties({
@@ -740,7 +753,7 @@ export abstract class BaseProvider extends AbstractProvider {
   _getEthGas = async (
     gasLimit: BigNumberish,
     storageLimit: BigNumberish,
-    _validUntil: BigNumberish
+    _validUntil?: BigNumberish
   ): Promise<{
     gasPrice: BigNumber;
     gasLimit: BigNumber;
@@ -867,9 +880,9 @@ export abstract class BaseProvider extends AbstractProvider {
 
   queryAccountInfo = async (
     addressOrName: string | Promise<string>,
-    blockTag?: BlockTag | Promise<BlockTag>
+    _blockTag?: BlockTag | Promise<BlockTag>
   ): Promise<Option<EvmAccountInfo>> => {
-    await this._ensureSafeModeFinalization(blockTag);
+    const blockTag = await this._ensureSafeModeBlockTagFinalization(_blockTag);
 
     // pending tag
     const resolvedBlockTag = await blockTag;
@@ -1200,20 +1213,17 @@ export abstract class BaseProvider extends AbstractProvider {
     return result;
   };
 
-  _getBlockHash = async (blockTag?: BlockTag | Promise<BlockTag>): Promise<string> => {
-    blockTag = await blockTag;
-
-    if (blockTag === undefined) {
-      blockTag = 'latest';
-    }
+  _getBlockHash = async (_blockTag?: BlockTag | Promise<BlockTag>): Promise<string> => {
+    const blockTag = await _blockTag || 'latest';
 
     switch (blockTag) {
       case 'pending': {
         return logger.throwError('pending tag not implemented', Logger.errors.UNSUPPORTED_OPERATION);
       }
       case 'latest': {
-        const hash = await this.api.rpc.chain.getBlockHash();
-        return hash.toHex();
+        return this.safeMode
+          ? this.latestFinalizedBlockHash!
+          : (await this.api.rpc.chain.getBlockHash()).toHex();
       }
       case 'earliest': {
         const hash = this.api.genesisHash;
@@ -1272,17 +1282,21 @@ export abstract class BaseProvider extends AbstractProvider {
     );
   };
 
-  _ensureSafeModeFinalization = async (blockTag: BlockTag | Promise<BlockTag> | undefined): Promise<void> => {
-    if (!this.safeMode || !blockTag) return;
+  _ensureSafeModeBlockTagFinalization = async (blockTag: BlockTagish): Promise<BlockTagish> => {
+    if (!this.safeMode || !blockTag) return blockTag;
+
+    if (blockTag === 'latest') return this.latestFinalizedBlockHash;
 
     const isBlockFinalized = await this._isBlockFinalized(await blockTag);
 
-    // We can also throw header not found error here, which is more consistent with actual block not found error. However, This error is more informative.
-    !isBlockFinalized && logger.throwError(
-      'SAFE MODE ERROR: target block is not finalized',
-      Logger.errors.UNKNOWN_ERROR,
-      { blockTag }
-    );
+    return isBlockFinalized
+      ? blockTag
+      // We can also throw header not found error here, which is more consistent with actual block not found error. However, This error is more informative.
+      : logger.throwError(
+        'SAFE MODE ERROR: target block is not finalized',
+        Logger.errors.UNKNOWN_ERROR,
+        { blockTag }
+      );
   };
 
   _getBlockHeader = async (blockTag?: BlockTag | Promise<BlockTag>): Promise<Header> => {
@@ -1372,9 +1386,9 @@ export abstract class BaseProvider extends AbstractProvider {
   // @TODO Testing
   getTransactionReceiptAtBlock = async (
     hashOrNumber: number | string | Promise<string>,
-    blockTag: BlockTag | Promise<BlockTag>
+    _blockTag: BlockTag | Promise<BlockTag>
   ): Promise<TransactionReceipt> => {
-    await this._ensureSafeModeFinalization(blockTag);
+    const blockTag = await this._ensureSafeModeBlockTagFinalization(_blockTag);
 
     hashOrNumber = await hashOrNumber;
     const header = await this._getBlockHeader(blockTag);

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -30,3 +30,5 @@ export const filterLog = (log: Log, filter: any): boolean => {
 };
 
 export const toHex = (x: number): string => `0x${x.toString(16)}`;
+
+export const sleep = (interval = 1000): Promise<void> => new Promise(resolve => setTimeout(resolve, interval))


### PR DESCRIPTION
## Change
### updated rules for the safe mode world
- `latest` blockTag refers to "latest finalized block", and passing unfinalized blockTag (hash/number) will throw "block not finalized" error. Scope:
  - eth_blockNumber
  - eth_call
  - eth_getTransactionCount
  - eth_getCode
  - eth_getBalance
  - eth_getStorageAt
  - eth_getTransactionByBlockHashAndIndex
  - eth_getTransactionByBlockNumberAndIndex
  - eth_getBlockTransactionCountByHash
  - eth_getBlockTransactionCountByNumber
- transaction and logs can only be found after they are finalized. Scope:
  - eth_getTransactionByHash
  - eth_getTransactionReceipt
  - eth_getLogs (this is actually the same as normal mode)
- subscription will only be notified for new **finalized** blocks. Scope:
  - eth_subscribe
- everything else works the same as normal mode

## Test
- added tests for the core helper `_ensureSafeModeBlockTagFinalization`, and a couple other functions calling `latest` blockTag 
- manually tested `eth_getTransactionByHash` and `eth_getTransactionReceipt` to make sure they can only find finalized TX, and `eth_subscribe` only callback from finalized blocks.