### PR TITLE
getEthGas polish

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -191,7 +191,6 @@ export abstract class BaseProvider extends AbstractProvider {
     this.safeMode = safeMode;
     this.latestFinalizedBlockHash = undefined;
 
-    logger.info(`safe mode: ${safeMode}`);
     safeMode && logger.warn(`
       ----------------------------- WARNING ----------------------------
       SafeMode is ON, and RPCs behave very differently than usual world!
@@ -212,7 +211,6 @@ export abstract class BaseProvider extends AbstractProvider {
     if (maxCachedSize < 1) {
       return logger.throwError(`expect maxCachedSize > 0, but got ${maxCachedSize}`, Logger.errors.INVALID_ARGUMENT);
     } else {
-      logger.info(`max cached blocks: ${maxCachedSize}`);
       maxCachedSize > 9999 && logger.warn(`
         ------------------- WARNING -------------------
         Max cached blocks is big, please be cautious!
@@ -761,6 +759,7 @@ export abstract class BaseProvider extends AbstractProvider {
 
   /**
    * helper to get ETH gas when don't know the whole transaction
+   * default to return big enough gas for contract deployment
    * @returns The gas used by eth transaction
    */
   _getEthGas = async({

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -763,11 +763,15 @@ export abstract class BaseProvider extends AbstractProvider {
    * helper to get ETH gas when don't know the whole transaction
    * @returns The gas used by eth transaction
    */
-  _getEthGas = async (
-    gasLimit: BigNumberish,
-    storageLimit: BigNumberish,
-    _validUntil?: BigNumberish
-  ): Promise<{
+  _getEthGas = async({
+    gasLimit = 21000000,
+    storageLimit = 64100,
+    validUntil: _validUntil,
+  }: {
+    gasLimit?: BigNumberish;
+    storageLimit?: BigNumberish;
+    validUntil?: BigNumberish;
+  } = {}): Promise<{
     gasPrice: BigNumber;
     gasLimit: BigNumber;
   }> => {

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -837,6 +837,7 @@ describe('eth_getEthGas', () => {
     const storageLimit = 64100;
     const validUntil = 1000000;
 
+    // correspond to validUntil = 1000000
     const defaultResults1 = await Promise.all([
       eth_getEthGas([{ gasLimit, storageLimit, validUntil }]),
       eth_getEthGas([{ gasLimit, validUntil }]),
@@ -851,6 +852,7 @@ describe('eth_getEthGas', () => {
       expect(parseInt(gas.gasPrice)).to.equal(202184524778);
     }
 
+    // correspond to validUntil = curBlock + 150
     const defaultResults2 = await Promise.all([
       eth_getEthGas([{ gasLimit }]),
       eth_getEthGas([{ storageLimit }]),

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -831,6 +831,7 @@ describe('eth_call', () => {
 
 describe('eth_getEthGas', () => {
   const eth_getEthGas = rpcGet('eth_getEthGas');
+  const eth_blockNumber = rpcGet('eth_blockNumber');
 
   it('get correct default contract deployment eth gas params', async () => {
     const gasLimit = 21000000;
@@ -853,6 +854,11 @@ describe('eth_getEthGas', () => {
     }
 
     // correspond to validUntil = curBlock + 150
+    const curBlock = parseInt((await eth_blockNumber()).data.result, 16);
+    const expectedGasPrice = parseInt((await eth_getEthGas([{
+      validUntil: curBlock + 150,
+    }])).data.result.gasPrice, 16);
+
     const defaultResults2 = await Promise.all([
       eth_getEthGas([{ gasLimit }]),
       eth_getEthGas([{ storageLimit }]),
@@ -865,7 +871,7 @@ describe('eth_getEthGas', () => {
       const gas = res.data.result;
 
       expect(parseInt(gas.gasLimit, 16)).to.equal(53064000);
-      expect(parseInt(gas.gasPrice)).to.equal(200007418858);
+      expect(parseInt(gas.gasPrice)).to.equal(expectedGasPrice);
     }
   });
 

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -832,14 +832,50 @@ describe('eth_call', () => {
 describe('eth_getEthGas', () => {
   const eth_getEthGas = rpcGet('eth_getEthGas');
 
-  it('get correct eth gas params', async () => {
-    const gasLimit = 1000010;
+  it('get correct default contract deployment eth gas params', async () => {
+    const gasLimit = 21000000;
     const storageLimit = 64100;
     const validUntil = 1000000;
-    const res = (await eth_getEthGas([gasLimit, storageLimit, validUntil])).data.result;
 
-    expect(parseInt(res.gasLimit, 16)).to.equal(33064010);
-    expect(parseInt(res.gasPrice)).to.equal(202184524778);
+    const defaultResults1 = await Promise.all([
+      eth_getEthGas([{ gasLimit, storageLimit, validUntil }]),
+      eth_getEthGas([{ gasLimit, validUntil }]),
+      eth_getEthGas([{ storageLimit, validUntil }]),
+      eth_getEthGas([{ validUntil }]),
+    ]);
+
+    for (const res of defaultResults1) {
+      const gas = res.data.result;
+
+      expect(parseInt(gas.gasLimit, 16)).to.equal(53064000);
+      expect(parseInt(gas.gasPrice)).to.equal(202184524778);
+    }
+
+    const defaultResults2 = await Promise.all([
+      eth_getEthGas([{ gasLimit }]),
+      eth_getEthGas([{ storageLimit }]),
+      eth_getEthGas([{ gasLimit, storageLimit }]),
+      eth_getEthGas([{}]),
+      eth_getEthGas([]),
+    ]);
+
+    for (const res of defaultResults2) {
+      const gas = res.data.result;
+
+      expect(parseInt(gas.gasLimit, 16)).to.equal(53064000);
+      expect(parseInt(gas.gasPrice)).to.equal(200007418858);
+    }
+  });
+
+  it('get correct custom eth gas params', async () => {
+    const gasLimit = 12345678;
+    const storageLimit = 30000;
+    const validUntil = 876543;
+
+    const gas = (await eth_getEthGas([{ gasLimit, storageLimit, validUntil }])).data.result;
+
+    expect(parseInt(gas.gasLimit, 16)).to.equal(27353678);
+    expect(parseInt(gas.gasPrice)).to.equal(201914843605);
   });
 });
 

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -885,6 +885,14 @@ describe('eth_getEthGas', () => {
     expect(parseInt(gas.gasLimit, 16)).to.equal(27353678);
     expect(parseInt(gas.gasPrice)).to.equal(201914843605);
   });
+
+  it('throws error when params are not valid', async () => {
+    const res = await eth_getEthGas([{ anyParam: 12345 }]);
+
+    expect(res.status).to.equal(200);
+    expect(res.data.error.code).to.equal(-32602);
+    expect(res.data.error.message).to.contain(`parameter can only be 'storageLimit' | 'gasLimit' | 'validUntil'`);
+  });
 });
 
 describe('eth_getCode', () => {

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -275,7 +275,8 @@ class Eip1193BridgeImpl {
     gasPrice: string;
     gasLimit: string;
   }> {
-    const res = await this.#provider._getEthGas(params[0], params[1], params[2]);
+    const res = await this.#provider._getEthGas(params[0]);
+
     return {
       gasPrice: hexValue(res.gasPrice),
       gasLimit: hexValue(res.gasLimit)

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -275,6 +275,8 @@ class Eip1193BridgeImpl {
     gasPrice: string;
     gasLimit: string;
   }> {
+    validate([{ type: 'substrateGasParams?' }], params);
+
     const res = await this.#provider._getEthGas(params[0]);
 
     return {

--- a/eth-rpc-adapter/src/server.ts
+++ b/eth-rpc-adapter/src/server.ts
@@ -46,9 +46,9 @@ export async function start() {
   await provider.isReady();
 
   console.log(`-------- 🚀 SERVER STARTED 🚀 --------`);
-  console.log(`endpoint url :  ${ENDPOINT_URL}`);
-  console.log(`subquery url :  ${SUBQL_URL}`);
-  console.log(`listening to :  http ${HTTP_PORT} | ws ${WS_PORT}`);
+  console.log(`endpoint url : ${ENDPOINT_URL}`);
+  console.log(`subquery url : ${SUBQL_URL}`);
+  console.log(`listening to : http ${HTTP_PORT} | ws ${WS_PORT}`);
   console.log(`max cacheSize: ${MAX_CACHE_SIZE}`);
   console.log(`safe mode    : ${SAFE_MODE}`);
   console.log(`--------------------------------------`);

--- a/eth-rpc-adapter/src/server.ts
+++ b/eth-rpc-adapter/src/server.ts
@@ -8,6 +8,8 @@ import { Router } from './router';
 dotenv.config();
 
 export async function start() {
+  console.log('starting server ...');
+
   const ENDPOINT_URL = process.env.ENDPOINT_URL || 'ws://0.0.0.0::9944';
   const SUBQL_URL = process.env.SUBQL_URL || 'http://0.0.0.0:3001';
   const HTTP_PORT = Number(process.env.HTTP_PORT || 8545);
@@ -41,11 +43,13 @@ export async function start() {
   HTTPTransport.start();
   WebSocketTransport.start();
 
-  console.log('starting server ...');
-
   await provider.isReady();
 
-  console.log(`server started with ${ENDPOINT_URL}`);
-  console.log(`subquery url: ${process.env.SUBQL_URL || 'http://localhost:3001'}`);
-  console.log(`listening to: HTTP ${HTTP_PORT}, WS: ${WS_PORT}`);
+  console.log(`-------- 🚀 SERVER STARTED 🚀 --------`);
+  console.log(`endpoint url :  ${ENDPOINT_URL}`);
+  console.log(`subquery url :  ${SUBQL_URL}`);
+  console.log(`listening to :  http ${HTTP_PORT} | ws ${WS_PORT}`);
+  console.log(`max cacheSize: ${MAX_CACHE_SIZE}`);
+  console.log(`safe mode    : ${SAFE_MODE}`);
+  console.log(`--------------------------------------`);
 }

--- a/eth-rpc-adapter/src/validate.ts
+++ b/eth-rpc-adapter/src/validate.ts
@@ -14,7 +14,8 @@ export type Schema = {
     | 'object?'
     | 'message'
     | 'hexNumber'
-    | 'eventName';
+    | 'eventName'
+    | 'substrateGasParams?';
 }[];
 
 export const validateEventName = (value: any) => {
@@ -102,6 +103,18 @@ export const validateObject = (data: any) => {
   }
 };
 
+export const validateSubstrateGasParams = (data: any) => {
+  if (data.constructor !== Object) {
+    throw new Error(`invalid args, expected Object`);
+  }
+
+  for (const k of Object.keys(data)) {
+    if (!['storageLimit', 'gasLimit', 'validUntil'].includes(k)) {
+      throw new Error(`parameter can only be 'storageLimit' | 'gasLimit' | 'validUntil'`);
+    }
+  }
+};
+
 export const validate = (schema: Schema, data: unknown[]) => {
   const maxArg = schema.length;
 
@@ -166,6 +179,10 @@ export const validate = (schema: Schema, data: unknown[]) => {
         }
         case 'eventName': {
           validateEventName(data[i] as any);
+          break;
+        }
+        case 'substrateGasParams?': {
+          data[i] && validateSubstrateGasParams(data[i] as any);
           break;
         }
         default:


### PR DESCRIPTION
## Change
### previous interface
```
{
  "method": "eth_getEthGas",
  "params": [21000000, 64100, 1000000]
}
```

### new interface
```
{
  "method": "eth_getEthGas",
  "params": [{
      "gasLimit?": 21000000,
      "storageLimit?": 64100,
      "validUntil?": 1000000
  }]
}
```
There are two advantages:
- named params are easier for developers to follow
- now every param is optional, so developers can do the following default query to get default gas params for big gas operations, such as contract deployment.  
```
{
  "method": "eth_getEthGas",
  "params": []
}
----- OR -----
{
  "method": "eth_getEthGas",
  "params": [{}]
}
```
which returns same result as
```
{
  "method": "eth_getEthGas",
  "params": [{
      "gasLimit": 21000000,
      "storageLimit": 64100,
      "validUntil": currentBlock + 150
  }]
}
```

## Test
added tests accordingly