### PR TITLE
timeout 6s x 2

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1551,7 +1551,7 @@ export abstract class BaseProvider extends AbstractProvider {
     return false;
   };
 
-  _getTXReceiptFromNextBlock = async (txHash: string, timeout = 20000): Promise<TransactionReceipt | null> => {
+  _getTXReceiptFromNextBlock = async (txHash: string, timeout = 6000): Promise<TransactionReceipt | null> => {
     return await Promise.race([
       sleep(timeout),
       new Promise<TransactionReceipt | null>((resolve) => {

--- a/eth-rpc-adapter/src/utils/utils.ts
+++ b/eth-rpc-adapter/src/utils/utils.ts
@@ -5,7 +5,7 @@ export const sleep = async (time: number = 1000): Promise<void> => new Promise((
 export const runWithRetries = async <F extends AnyFunction>(
   fn: F,
   args: any[] = [],
-  maxRetries: number = 3,
+  maxRetries: number = 2,
   interval: number = 1000,
 ): Promise<F extends (...args: any[]) => infer R ? R : any> => {
   let res;


### PR DESCRIPTION
currently the timeout is too big, 20s x 3, when testing with mandala there are too many timeout, so decrease the timeout to 6s x 2 = 12s. Will do more experiment on what happens if these two conditions both satisfied for pending tx (this seems to be more standard behavior):
- return null directly for `eth_getTransactionReceipt`
- return partial tx for `eth_getTransactionByHash`