### PR TITLE
Fix `used_gas` and `used_storage ` Type

### DIFF
--- a/eth-providers/src/utils/transactionReceiptHelper.ts
+++ b/eth-providers/src/utils/transactionReceiptHelper.ts
@@ -60,13 +60,29 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
     effectiveGasPrice: EFFECTIVE_GAS_PRICE
   };
 
+  /* --------------- TODO:
+     for newer versions of mandala, used_gas's shape is:
+     ```
+      used_gas: u64 {
+        negative: 0,
+        words: [ 21000 ],
+        length: 1,
+        red: null,
+        registry: TypeRegistry {},
+        encodedLength: 8,
+        __UIntType: 'u64'
+      },
+      ```
+      and `typeof used_gas === 'object'`
+      if this is expected, then we can convert this object to bigNumber gasPrice
+                                                                 --------------- */
   switch (event.event.method) {
     case 'Created': {
       const [source, evmAddress, logs, used_gas, _used_storage] = event.event.data as unknown as [
         H160,
         H160,
         EvmLog[],
-        BigNumber,
+        any,
         BigNumber
       ];
 
@@ -74,7 +90,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         to: undefined,
         from: source.toHex(),
         contractAddress: evmAddress.toString(),
-        gasUsed: used_gas || BIGNUMBER_ZERO,
+        gasUsed: ((used_gas.constructor === BigNumber) && used_gas) || BIGNUMBER_ZERO,
         status: 1,
         logs: getPartialLogs(logs),
         ...defaultValue
@@ -85,7 +101,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         H160,
         H160,
         EvmLog[],
-        BigNumber,
+        any,
         BigNumber
       ];
 
@@ -93,7 +109,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         to: evmAddress.toString(),
         from: source.toHex(),
         contractAddress: evmAddress.toString(),
-        gasUsed: used_gas || BIGNUMBER_ZERO,
+        gasUsed: ((used_gas.constructor === BigNumber) && used_gas) || BIGNUMBER_ZERO,
         logs: getPartialLogs(logs),
         status: 1,
         ...defaultValue
@@ -105,7 +121,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         H160,
         ExitReason,
         EvmLog[],
-        BigNumber,
+        any,
         BigNumber
       ];
 
@@ -113,7 +129,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         to: undefined,
         from: source.toHex(),
         contractAddress: evmAddress.toString(),
-        gasUsed: used_gas || BIGNUMBER_ZERO,
+        gasUsed: ((used_gas.constructor === BigNumber) && used_gas) || BIGNUMBER_ZERO,
         logs: getPartialLogs(logs),
         status: 0,
         exitReason: _exitReason.toString(),
@@ -127,7 +143,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         ExitReason,
         unknown,
         EvmLog[],
-        BigNumber,
+        any,
         BigNumber
       ];
 
@@ -135,7 +151,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         to: evmAddress.toString(),
         from: source.toHex(),
         contractAddress: undefined,
-        gasUsed: used_gas || BIGNUMBER_ZERO,
+        gasUsed: ((used_gas.constructor === BigNumber) && used_gas) || BIGNUMBER_ZERO,
         status: 0,
         exitReason: _exitReason.toString(),
         logs: getPartialLogs(logs),

--- a/eth-providers/src/utils/transactionReceiptHelper.ts
+++ b/eth-providers/src/utils/transactionReceiptHelper.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { isHexString } from '@ethersproject/bytes';
 import { Logger } from '@ethersproject/logger';
-import type { GenericExtrinsic, u64 } from '@polkadot/types';
+import type { GenericExtrinsic, i32, u64 } from '@polkadot/types';
 import type { EventRecord } from '@polkadot/types/interfaces';
 import type { EvmLog, H160, ExitReason } from '@polkadot/types/interfaces/types';
 import type { FrameSystemEventRecord } from '@polkadot/types/lookup';
@@ -67,7 +67,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         H160,
         EvmLog[],
         u64?,
-        u64?,
+        i32?,
       ];
 
       return {
@@ -86,7 +86,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         H160,
         EvmLog[],
         u64?,
-        u64?,
+        i32?,
       ];
 
       return {
@@ -106,7 +106,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         ExitReason,
         EvmLog[],
         u64?,
-        u64?,
+        i32?,
       ];
 
       return {
@@ -128,7 +128,7 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         unknown,
         EvmLog[],
         u64?,
-        u64?,
+        i32?,
       ];
 
       return {

--- a/eth-providers/src/utils/transactionReceiptHelper.ts
+++ b/eth-providers/src/utils/transactionReceiptHelper.ts
@@ -74,8 +74,9 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
       },
       ```
       and `typeof used_gas === 'object'`
-      if this is expected, then we can convert this object to bigNumber gasPrice
-                                                                 --------------- */
+
+      we should confirm this shape
+                                         --------------- */
   switch (event.event.method) {
     case 'Created': {
       const [source, evmAddress, logs, used_gas, _used_storage] = event.event.data as unknown as [
@@ -83,14 +84,18 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         H160,
         EvmLog[],
         any,
-        BigNumber
+        any,
       ];
+
+      const gasUsed = used_gas.constructor === BigNumber
+        ? used_gas
+        : used_gas.words?.[0];
 
       return {
         to: undefined,
         from: source.toHex(),
         contractAddress: evmAddress.toString(),
-        gasUsed: ((used_gas.constructor === BigNumber) && used_gas) || BIGNUMBER_ZERO,
+        gasUsed: BigNumber.from(gasUsed || 0),
         status: 1,
         logs: getPartialLogs(logs),
         ...defaultValue
@@ -102,14 +107,18 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         H160,
         EvmLog[],
         any,
-        BigNumber
+        any,
       ];
+
+      const gasUsed = used_gas.constructor === BigNumber
+        ? used_gas
+        : used_gas.words?.[0];
 
       return {
         to: evmAddress.toString(),
         from: source.toHex(),
         contractAddress: evmAddress.toString(),
-        gasUsed: ((used_gas.constructor === BigNumber) && used_gas) || BIGNUMBER_ZERO,
+        gasUsed: BigNumber.from(gasUsed || 0),
         logs: getPartialLogs(logs),
         status: 1,
         ...defaultValue
@@ -122,14 +131,18 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         ExitReason,
         EvmLog[],
         any,
-        BigNumber
+        any,
       ];
+
+      const gasUsed = used_gas.constructor === BigNumber
+        ? used_gas
+        : used_gas.words?.[0];
 
       return {
         to: undefined,
         from: source.toHex(),
         contractAddress: evmAddress.toString(),
-        gasUsed: ((used_gas.constructor === BigNumber) && used_gas) || BIGNUMBER_ZERO,
+        gasUsed: BigNumber.from(gasUsed || 0),
         logs: getPartialLogs(logs),
         status: 0,
         exitReason: _exitReason.toString(),
@@ -144,14 +157,18 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         unknown,
         EvmLog[],
         any,
-        BigNumber
+        any,
       ];
+
+      const gasUsed = used_gas.constructor === BigNumber
+        ? used_gas
+        : used_gas.words?.[0];
 
       return {
         to: evmAddress.toString(),
         from: source.toHex(),
         contractAddress: undefined,
-        gasUsed: ((used_gas.constructor === BigNumber) && used_gas) || BIGNUMBER_ZERO,
+        gasUsed: BigNumber.from(gasUsed || 0),
         status: 0,
         exitReason: _exitReason.toString(),
         logs: getPartialLogs(logs),

--- a/eth-providers/src/utils/transactionReceiptHelper.ts
+++ b/eth-providers/src/utils/transactionReceiptHelper.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { isHexString } from '@ethersproject/bytes';
 import { Logger } from '@ethersproject/logger';
-import type { GenericExtrinsic } from '@polkadot/types';
+import type { GenericExtrinsic, u64 } from '@polkadot/types';
 import type { EventRecord } from '@polkadot/types/interfaces';
 import type { EvmLog, H160, ExitReason } from '@polkadot/types/interfaces/types';
 import type { FrameSystemEventRecord } from '@polkadot/types/lookup';
@@ -60,42 +60,21 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
     effectiveGasPrice: EFFECTIVE_GAS_PRICE
   };
 
-  /* --------------- TODO:
-     for newer versions of mandala, used_gas's shape is:
-     ```
-      used_gas: u64 {
-        negative: 0,
-        words: [ 21000 ],
-        length: 1,
-        red: null,
-        registry: TypeRegistry {},
-        encodedLength: 8,
-        __UIntType: 'u64'
-      },
-      ```
-      and `typeof used_gas === 'object'`
-
-      we should confirm this shape
-                                         --------------- */
   switch (event.event.method) {
     case 'Created': {
       const [source, evmAddress, logs, used_gas, _used_storage] = event.event.data as unknown as [
         H160,
         H160,
         EvmLog[],
-        any,
-        any,
+        u64?,
+        u64?,
       ];
-
-      const gasUsed = used_gas.constructor === BigNumber
-        ? used_gas
-        : used_gas.words?.[0];
 
       return {
         to: undefined,
         from: source.toHex(),
         contractAddress: evmAddress.toString(),
-        gasUsed: BigNumber.from(gasUsed || 0),
+        gasUsed: BigNumber.from(used_gas?.toString() || 0),
         status: 1,
         logs: getPartialLogs(logs),
         ...defaultValue
@@ -106,19 +85,15 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         H160,
         H160,
         EvmLog[],
-        any,
-        any,
+        u64?,
+        u64?,
       ];
-
-      const gasUsed = used_gas.constructor === BigNumber
-        ? used_gas
-        : used_gas.words?.[0];
 
       return {
         to: evmAddress.toString(),
         from: source.toHex(),
         contractAddress: evmAddress.toString(),
-        gasUsed: BigNumber.from(gasUsed || 0),
+        gasUsed: BigNumber.from(used_gas?.toString() || 0),
         logs: getPartialLogs(logs),
         status: 1,
         ...defaultValue
@@ -130,19 +105,15 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         H160,
         ExitReason,
         EvmLog[],
-        any,
-        any,
+        u64?,
+        u64?,
       ];
-
-      const gasUsed = used_gas.constructor === BigNumber
-        ? used_gas
-        : used_gas.words?.[0];
 
       return {
         to: undefined,
         from: source.toHex(),
         contractAddress: evmAddress.toString(),
-        gasUsed: BigNumber.from(gasUsed || 0),
+        gasUsed: BigNumber.from(used_gas?.toString() || 0),
         logs: getPartialLogs(logs),
         status: 0,
         exitReason: _exitReason.toString(),
@@ -156,19 +127,15 @@ export const getPartialTransactionReceipt = (event: FrameSystemEventRecord): Par
         ExitReason,
         unknown,
         EvmLog[],
-        any,
-        any,
+        u64?,
+        u64?,
       ];
-
-      const gasUsed = used_gas.constructor === BigNumber
-        ? used_gas
-        : used_gas.words?.[0];
 
       return {
         to: evmAddress.toString(),
         from: source.toHex(),
         contractAddress: undefined,
-        gasUsed: BigNumber.from(gasUsed || 0),
+        gasUsed: BigNumber.from(used_gas?.toString() || 0),
         status: 0,
         exitReason: _exitReason.toString(),
         logs: getPartialLogs(logs),


### PR DESCRIPTION
## Change
`used_gas` type should be `u64`
`used_storage` type should be `i32`

After this fix we should be able to deploy latest RPC adaptor to mandala.

## Test
Manually tested:
- Before the fix: running a rpc adaptor connecting to `wss://mandala-tc7-rpcnode.aca-dev.network/ws`, metamaks can't send tx and hardhat hello world deployment failed. Both because `eth_getTransactionReceipt` fails.
- After the fix: metamask sending tx works and deploying hello world works