### PR TITLE
add docker compose for running rpc adaptor

### DIFF
--- a/eth-rpc-adapter/README.md
+++ b/eth-rpc-adapter/README.md
@@ -2,6 +2,7 @@
 A node service that allows existing Ethereum dApp to be able to interact with [Acala EVM](https://github.com/AcalaNetwork/Acala/tree/master/modules/evm).
 
 ## Run
+### run with local build
 - provide an optional `.env` file for:
   - **ENDPOINT_URL**: acala node WS url
   - **SUBQL_URL**: subquery service url
@@ -30,6 +31,11 @@ rush update
 - run the dev server:
 ```
 yarn dev
+```
+
+### run with docker
+```
+docker compose up
 ```
 
 ## Usage

--- a/eth-rpc-adapter/README.md
+++ b/eth-rpc-adapter/README.md
@@ -37,6 +37,7 @@ yarn dev
 ```
 docker compose up
 ```
+note that docker image might not be most up-to-date. Latest image can be found [here](https://hub.docker.com/r/acala/eth-rpc-adapter/tags)
 
 ## Usage
 Now that the adaptor service is running and listening to HTTP_PORT, we can send EVM related requests to this port.

--- a/eth-rpc-adapter/docker-compose.yml
+++ b/eth-rpc-adapter/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+
+services:
+  mandala-node:
+    image: ghcr.io/acalanetwork/mandala-node:sha-0916abb
+    ports:
+      - 9944:9944
+    command:
+      - --dev
+      - -lruntime=debug
+      - -levm=debug
+      - --ws-port=9944
+      - --ws-external
+      - --rpc-port=9933
+      - --rpc-external
+      - --rpc-cors=all
+      - --rpc-methods=unsafe
+      - --instant-sealing
+      - --tmp
+
+  eth-rpc-adaptor:
+    image: acala/eth-rpc-adapter:2a8cc61
+    ports:
+      - 8545:8545
+    depends_on:
+      - mandala-node
+    restart: always
+    environment:
+      ENDPOINT_URL: ws://mandala-node:9944
+      LOCAL_MODE: 1


### PR DESCRIPTION
## Change
added docker compose file so developers can run a local mode mandala + rpc adaptor with one command `docker compose up`.

This will lower the barrier for developers who want to try running the stack locally, also it's a remedy when public mandala has some issue.

## Test
`docker compose up` to run the stack, and all truffle tutorials still pass