### PR TITLE
Revert "remove fixed deps"

### DIFF
--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -18,32 +18,31 @@ module.exports = {
   }
 };
 
-// const polkadotDeps = {
-//   "@polkadot/api": "~8.1.1",
-//   "@polkadot/api-derive": "~8.1.1",
-//   '@polkadot/api-augment': "~8.1.1",
-//   "@polkadot/types": "~8.1.1",
-//   "@polkadot/types-known": "~8.1.1",
-//   "@polkadot/rpc-core": "~8.1.1",
-//   "@polkadot/rpc-provider": "~8.1.1",
-//   "@polkadot/keyring": "~9.0.1",
-//   "@polkadot/util": "~9.0.1",
-//   "@polkadot/util-crypto": "~9.0.1",
-//   "@acala-network/types": "~4.1.1",
-// }
+const polkadotDeps = {
+  "@polkadot/api": "~8.1.1",
+  "@polkadot/api-derive": "~8.1.1",
+  '@polkadot/api-augment': "~8.1.1",
+  "@polkadot/types": "~8.1.1",
+  "@polkadot/types-known": "~8.1.1",
+  "@polkadot/rpc-core": "~8.1.1",
+  "@polkadot/rpc-provider": "~8.1.1",
+  "@polkadot/keyring": "~9.0.1",
+  "@polkadot/util": "~9.0.1",
+  "@polkadot/util-crypto": "~9.0.1",
+  "@acala-network/types": "~4.1.1",
+}
 
 const fixedDeps = {
-  // ...polkadotDeps,
-  // ...ethersDeps,
+  ...polkadotDeps,
   "bn.js": "4.12.0",
   "@types/bn.js": "5.1.0",
 } 
 
-// const projects = [
-//   "@acala-network/eth-rpc-adapter",
-//   "@acala-network/evm-subql",
-//   "@acala-network/bodhi"
-// ]
+const projects = [
+  "@acala-network/eth-rpc-adapter",
+  "@acala-network/evm-subql",
+  "@acala-network/bodhi"
+]
 
 /**
  * This hook is invoked during installation before a package's dependencies


### PR DESCRIPTION
## Change
Reverts AcalaNetwork/bodhi.js#390

waffle examples will still have the deps warning without these locks :
- with lock, no warnings: https://github.com/AcalaNetwork/bodhi.js/runs/6102942438?check_suite_focus=true
- without lock, has warnings: https://github.com/AcalaNetwork/bodhi.js/runs/6104611253?check_suite_focus=true

This is because waffle examples rely on `@acala-network/api` which has [outdated dependecies](https://github.com/AcalaNetwork/acala.js/blob/master/packages/api/package.json#L22), so this warning should only affect waffle examples. I think it should be fine if we just leave it as is, and after `@acala-network/api` is updated the errors will go awao. 

What do you think @ntduan ? Do you prefer keep the locks or remove them