### PR TITLE
allow passing multiple endpoints and two new RPCs to check finalization

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1492,6 +1492,13 @@ export abstract class BaseProvider extends AbstractProvider {
     return finalizedBlockNumber >= verifyingBlockNumber && canonicalHash.toString() === verifyingBlockHash;
   };
 
+  _isTransactionFinalized = async (txHash: string): Promise<boolean> => {
+    const tx = await this._getMinedTXReceipt(txHash);
+    if (!tx) return false;
+
+    return await this._isBlockFinalized(tx.blockHash);
+  };
+
   _ensureSafeModeBlockTagFinalization = async (_blockTag: BlockTagish): Promise<BlockTagish> => {
     if (!this.safeMode || !_blockTag) return _blockTag;
 

--- a/eth-rpc-adapter/README.md
+++ b/eth-rpc-adapter/README.md
@@ -116,8 +116,8 @@ These are EVM+ custom RPCs that only exist on Acala/Karura
 - `net_cacheInfo`: get the cache info
 - `net_isSafeMode`: check if this RPC is running in safe mode
 - `net_health`: check the health of the RPC endpoint
-- `eth_isBlockFinalized`: check the health of the RPC endpoint, params: [BlockTag](https://docs.ethers.io/v5/api/providers/types/#providers-BlockTag)
-- `eth_isTransactionFinalized`: check the health of the RPC endpoint, params: string
+- `eth_isBlockFinalized`: check if a block is finalized, params: [BlockTag](https://docs.ethers.io/v5/api/providers/types/#providers-BlockTag)
+- `eth_isTransactionFinalized`: check if a transaction is finalized, note that it also returns false for non-exist tx, params: string
 
 ## Test
 ```

--- a/eth-rpc-adapter/README.md
+++ b/eth-rpc-adapter/README.md
@@ -110,12 +110,14 @@ These are ETH compatible RPCs, the interface and functionalities match https://e
 
 ### Custom RPCs
 These are EVM+ custom RPCs that only exist on Acala/Karura
-- `eth_getEthGas`: calculate eth transaction gas params from substrate gas params. More details please refer (here)[link to doc]
-- `eth_getEthResources`: calculate eth transaction gas params from transaction details
+- `eth_getEthGas`: calculate eth transaction gas params from substrate gas params. More details please refer [here](https://evmdocs.acala.network/network/gas-parameters)]
+- `eth_getEthResources`: calculate eth transaction gas params from transaction details, params: [TransactionRequest](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionRequest)
 - `net_indexer`: get subql indexer metadata
 - `net_cacheInfo`: get the cache info
 - `net_isSafeMode`: check if this RPC is running in safe mode
 - `net_health`: check the health of the RPC endpoint
+- `eth_isBlockFinalized`: check the health of the RPC endpoint, params: [BlockTag](https://docs.ethers.io/v5/api/providers/types/#providers-BlockTag)
+- `eth_isTransactionFinalized`: check the health of the RPC endpoint, params: string
 
 ## Test
 ```

--- a/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -412,6 +412,16 @@ class Eip1193BridgeImpl {
     return null;
   }
 
+  async eth_isBlockFinalized(params: any[]): Promise<any> {
+    validate([{ type: 'block' }], params);
+    return await this.#provider._isBlockFinalized(params[0]);
+  }
+
+  async eth_isTransactionFinalized(params: any[]): Promise<any> {
+    validate([{ type: 'trasactionHash' }], params);
+    return await this.#provider._isTransactionFinalized(params[0]);
+  }
+
   // async eth_newFilter(params: any[]): Promise<any> {
 
   // }

--- a/eth-rpc-adapter/src/server.ts
+++ b/eth-rpc-adapter/src/server.ts
@@ -21,7 +21,7 @@ export async function start(): Promise<void> {
   const MAX_BATCH_SIZE = Number(process.env.MAX_BATCH_SIZE || 50);
   const STORAGE_CACHE_SIZE = Number(process.env.STORAGE_CACHE_SIZE || 5000);
 
-  const provider = EvmRpcProvider.from(ENDPOINT_URL, {
+  const provider = EvmRpcProvider.from(ENDPOINT_URL.split(','), {
     safeMode: SAFE_MODE,
     localMode: LOCAL_MODE,
     maxCacheSize: MAX_CACHE_SIZE,


### PR DESCRIPTION
## Change
- allow pass multiple node urls like `ENDPOINT_URL=xxx,yyy,zzz yarn dev`
- implemented two RPCs: `eth_isBlockFinalized` and `eth_isTransactionFinalized`

fix #404
fix #396

## Test
manually tested that calling `eth_isBlockFinalized` for a new block in mandala, returns false, after a while returns true. Same for `eth_isTransactionFinalized`.