### PR TITLE
polish local mode

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1700,7 +1700,9 @@ export abstract class BaseProvider extends AbstractProvider {
 
     if (!targetBlockNumber) return null;
 
-    const targetBlockHash = await this.api.rpc.chain.getBlockHash(targetBlockNumber);
+    const targetBlockHash = this.localMode
+      ? await runWithRetries(async () => this.api.rpc.chain.getBlockHash(targetBlockNumber))
+      : await this.api.rpc.chain.getBlockHash(targetBlockNumber);
 
     return this.getTransactionReceiptAtBlock(txHash, targetBlockHash.toHex());
   };

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -49,9 +49,9 @@ export const isEVMExtrinsic = (e: Extrinsic): boolean => e.method.section.toUppe
 export const runWithRetries = async <F extends AnyFunction>(
   fn: F,
   args: any[] = [],
-  maxRetries: number = 100,
+  maxRetries: number = 200,
   interval: number = 100
-): Promise<F extends (...args: any[]) => infer R ? R : any> => {
+): Promise<F extends (...args: any[]) => infer R ? R : never> => {
   let res;
   let tries = 0;
 
@@ -62,10 +62,11 @@ export const runWithRetries = async <F extends AnyFunction>(
       if (tries === maxRetries) throw e;
     }
 
-    if (tries > 0 && !res) {
-      console.log(`empty result # ${tries}/${maxRetries}`);
-      await sleep(interval);
+    if ((tries === 1 || tries % 10 === 0) && !res) {
+      console.log(`<local mode runWithRetries> still waiting for result # ${tries}/${maxRetries}`);
     }
+
+    await sleep(interval);
   }
 
   return res;


### PR DESCRIPTION
## Change
in local mode added retry to `getblockhash` to remedy some timing issue with `--instant-sealing` that when receipt exists but `api.rpc.chain.getBlockHash` still returns `HEADER NOT FOUND`.

## Test
Found this issue when doing AAVE tests, after the fix the issue was gone.