### PR TITLE
[net_health] don't fetch very old random block

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1901,8 +1901,10 @@ export abstract class BaseProvider extends AbstractProvider {
       })
     );
 
+    // Distance allowed to fetch old random block (since most oldest block takes longer to fetch)
+    const BLOCK_DISTANCE = Number(process.env.HEALTH_CHECK_BLOCK_DISTANCE || 500);
     // ideally randBlockNumber should have EVM TX
-    const randBlockNumber = Math.floor(Math.random() * this.latestFinalizedBlockNumber!);
+    const randBlockNumber = Math.abs(Math.floor(this.latestFinalizedBlockNumber! - BLOCK_DISTANCE * Math.random()));
     const getBlockPromise = runWithTiming(async () => this.getBlock(randBlockNumber, false));
     const getFullBlockPromise = runWithTiming(async () => this.getBlock(randBlockNumber, true));
 

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -227,7 +227,7 @@ export abstract class BaseProvider extends AbstractProvider {
     localMode = false,
     subqlUrl,
     storageCacheSize = 5000,
-    healthCheckBlockDistance = 500
+    healthCheckBlockDistance = 100
   }: {
     safeMode?: boolean;
     localMode?: boolean;
@@ -1905,12 +1905,13 @@ export abstract class BaseProvider extends AbstractProvider {
       })
     );
 
-    // ideally randBlockNumber should have EVM TX
-    const randBlockNumber = Math.abs(
-      Math.floor(this.latestFinalizedBlockNumber! - this._healthCheckBlockDistance * Math.random())
-    );
-    const getBlockPromise = runWithTiming(async () => this.getBlock(randBlockNumber, false));
-    const getFullBlockPromise = runWithTiming(async () => this.getBlock(randBlockNumber, true));
+    // ideally pastNblock should have EVM TX
+    const pastNblock =
+      this.latestFinalizedBlockNumber! > this._healthCheckBlockDistance
+        ? this.latestFinalizedBlockNumber! - this._healthCheckBlockDistance
+        : this.latestFinalizedBlockNumber!;
+    const getBlockPromise = runWithTiming(async () => this.getBlock(pastNblock, false));
+    const getFullBlockPromise = runWithTiming(async () => this.getBlock(pastNblock, true));
 
     const [gasPriceTime, estimateGasTime, getBlockTime, getFullBlockTime] = (
       await Promise.all([gasPricePromise, estimateGasPromise, getBlockPromise, getFullBlockPromise])

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -214,7 +214,7 @@ export abstract class BaseProvider extends AbstractProvider {
   readonly subql?: SubqlProvider;
   readonly storages: WeakMap<VersionedRegistry<'promise'>, Storage> = new WeakMap();
   readonly _storageCache: LRUCache<string, Uint8Array | null>;
-  readonly _healthCheckBlockDistance: number;
+  readonly _healthCheckBlockDistance: number; // Distance allowed to fetch old random block (since most oldest block takes longer to fetch)
 
   _newBlockListeners: NewBlockListener[];
   _network?: Promise<Network>;
@@ -1905,10 +1905,10 @@ export abstract class BaseProvider extends AbstractProvider {
       })
     );
 
-    // Distance allowed to fetch old random block (since most oldest block takes longer to fetch)
-    const BLOCK_DISTANCE = this._healthCheckBlockDistance || 500;
     // ideally randBlockNumber should have EVM TX
-    const randBlockNumber = Math.abs(Math.floor(this.latestFinalizedBlockNumber! - BLOCK_DISTANCE * Math.random()));
+    const randBlockNumber = Math.abs(
+      Math.floor(this.latestFinalizedBlockNumber! - this._healthCheckBlockDistance * Math.random())
+    );
     const getBlockPromise = runWithTiming(async () => this.getBlock(randBlockNumber, false));
     const getFullBlockPromise = runWithTiming(async () => this.getBlock(randBlockNumber, true));
 

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -214,7 +214,7 @@ export abstract class BaseProvider extends AbstractProvider {
   readonly subql?: SubqlProvider;
   readonly storages: WeakMap<VersionedRegistry<'promise'>, Storage> = new WeakMap();
   readonly _storageCache: LRUCache<string, Uint8Array | null>;
-  readonly _healthCheckBlockDistance: number; // Distance allowed to fetch old random block (since most oldest block takes longer to fetch)
+  readonly _healthCheckBlockDistance: number; // Distance allowed to fetch old nth block (since most oldest block takes longer to fetch)
 
   _newBlockListeners: NewBlockListener[];
   _network?: Promise<Network>;


### PR DESCRIPTION
Problem:  `net_health` fetches random block to instrument time, due to which very old blocks are mostly fetched and that takes longer than fetching recent finalized blocks. Since `ApiPromise` is shared so it slows down other rpc calls of `WsProvider`

Solution: Added Limit to fetch random block but not below `BLOCK_DISTANCE`

_FUTURE TODO_ **Permenant Solution**: Should have multiple load balanced `ApiPromise` in `base-provider.ts`