### PR TITLE
bump v2.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.4.11 2022/05/16
+- bug fixes and improvements
+
 ## v2.4.9 2022/05/11
 - fix deps conflicts
 

--- a/bodhi/package.json
+++ b/bodhi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/bodhi",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "main": "lib/index.js",
   "repository": "git@github.com:AcalaNetwork/bodhi.js.git",
   "author": "Acala Developers <hello@acala.network>",

--- a/bodhi/src/_version.ts
+++ b/bodhi/src/_version.ts
@@ -1,1 +1,1 @@
-export const version: string = 'bodhi.js/bodhi/2.4.10';
+export const version: string = 'bodhi.js/bodhi/2.4.11';

--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/eth-providers",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "main": "lib/index.js",
   "license": "MIT",
   "author": "Acala Developers <hello@acala.network>",

--- a/eth-providers/src/_version.ts
+++ b/eth-providers/src/_version.ts
@@ -1,1 +1,1 @@
-export const version: string = 'bodhi.js/providers/2.4.10';
+export const version: string = 'bodhi.js/providers/2.4.11';

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1383,7 +1383,7 @@ export abstract class BaseProvider extends AbstractProvider {
           .subscribeNewHeads((head) => {
             const blockNumber = head.number.toNumber();
 
-            if ((confirms as number) <= blockNumber - startBlock) {
+            if ((confirms as number) <= blockNumber - startBlock + 1) {
               const receipt = this.getTransactionReceiptAtBlock(hash, startBlockHash);
               if (alreadyDone()) {
                 return;

--- a/eth-rpc-adapter/package.json
+++ b/eth-rpc-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/eth-rpc-adapter",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "main": "lib/index.js",
   "license": "MIT",
   "author": "Acala Developers <hello@acala.network>",

--- a/eth-rpc-adapter/src/_version.ts
+++ b/eth-rpc-adapter/src/_version.ts
@@ -1,1 +1,1 @@
-export const version: string = 'bodhi.js/eth-rpc-adapter/2.4.10';
+export const version: string = 'bodhi.js/eth-rpc-adapter/2.4.11';

--- a/eth-transactions/package.json
+++ b/eth-transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/eth-transactions",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "main": "lib/index.js",
   "license": "MIT",
   "author": "Acala Developers <hello@acala.network>",

--- a/eth-transactions/src/_version.ts
+++ b/eth-transactions/src/_version.ts
@@ -1,1 +1,1 @@
-export const version: string = 'bodhi.js/transactions/2.4.10';
+export const version: string = 'bodhi.js/transactions/2.4.11';


### PR DESCRIPTION
bump version and fixed the confirmation calculation in `sendTransaction` (first block should be confirmation 1), this is required for upgrdeable contract example to work with instant sealing