### PR TITLE
fix pending tx `to`

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -701,6 +701,7 @@ export abstract class BaseProvider extends AbstractProvider {
     return this.getEvmTransactionCount(addressOrName, blockTag);
   };
 
+  // TODO: test pending
   getEvmTransactionCount = async (
     addressOrName: string | Promise<string>,
     blockTag?: BlockTag | Promise<BlockTag>
@@ -1720,7 +1721,7 @@ export abstract class BaseProvider extends AbstractProvider {
     return this.getTransactionReceiptAtBlock(txHash, targetBlockHash.toHex());
   };
 
-  // TODO: test
+  // TODO: test pending
   _getPendingTX = async (txHash: string): Promise<TX | null> => {
     const pendingExtrinsics = await this.api.rpc.author.pendingExtrinsics();
     const targetExtrinsic = pendingExtrinsics.find((e) => e.hash.toHex() === txHash);

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1720,6 +1720,7 @@ export abstract class BaseProvider extends AbstractProvider {
     return this.getTransactionReceiptAtBlock(txHash, targetBlockHash.toHex());
   };
 
+  // TODO: test
   _getPendingTX = async (txHash: string): Promise<TX | null> => {
     const pendingExtrinsics = await this.api.rpc.author.pendingExtrinsics();
     const targetExtrinsic = pendingExtrinsics.find((e) => e.hash.toHex() === txHash);
@@ -1730,7 +1731,7 @@ export abstract class BaseProvider extends AbstractProvider {
 
     return {
       from: await this.getEvmAddress(targetExtrinsic.signer.toString()),
-      to: args.action.Call ? args.action.Call : null,
+      to: args.action.call ? args.action.call : null,
       blockHash: null,
       blockNumber: null,
       transactionIndex: null,


### PR DESCRIPTION
did we change `Call` to lower case sometime? anyways there is no test for it, so didn't catch it whenever the change happened. I just happened to notice pending tx doesn't return correct `to` anymore. 

## test
After the fix it can return correct data again.