### PR TITLE
fix to in `eth_getTransactionByHash`

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1526,7 +1526,7 @@ export abstract class BaseProvider extends AbstractProvider {
 
     return {
       extrinsic: block.block.extrinsics[extrinsicIndex],
-      extrinsicEvents: extrinsicEvents,
+      extrinsicEvents,
       transactionHash,
       transactionIndex,
       isExtrinsicFailed
@@ -1691,10 +1691,10 @@ export abstract class BaseProvider extends AbstractProvider {
       hash: tx.transactionHash,
       from: tx.from,
       gasPrice: tx.effectiveGasPrice,
-      ...parseExtrinsic(extrinsic)
+      ...parseExtrinsic(extrinsic),
 
-      // TODO: can use actual gas from receipt instead of provided gas from parseExtrinsic for consistency
-      // gas: tx.gasUsed,
+      // overrides to in parseExtrinsic, in case of non-evm events, such as dex
+      to: tx.to || null,
     };
   };
 

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1693,8 +1693,8 @@ export abstract class BaseProvider extends AbstractProvider {
       gasPrice: tx.effectiveGasPrice,
       ...parseExtrinsic(extrinsic),
 
-      // overrides to in parseExtrinsic, in case of non-evm events, such as dex
-      to: tx.to || null,
+      // overrides to in parseExtrinsic, in case of non-evm extrinsic, such as dex.xxx
+      to: tx.to || null
     };
   };
 

--- a/eth-providers/src/utils/transactionReceiptHelper.ts
+++ b/eth-providers/src/utils/transactionReceiptHelper.ts
@@ -242,6 +242,7 @@ export const getTransactionIndexAndHash = (
 };
 
 // parse info that can be extracted from extrinsic alone
+// only works for EVM extrinsics
 export const parseExtrinsic = (
   extrinsic: GenericExtrinsic
 ): {

--- a/examples/waffle/e2e/test/dex.test.ts
+++ b/examples/waffle/e2e/test/dex.test.ts
@@ -5,6 +5,7 @@ import { AccountSigningKey, Signer, evmChai } from '@acala-network/bodhi';
 import { EvmRpcProvider, hexlifyRpcResult } from '@acala-network/eth-providers';
 import TestToken from '../build/TestToken.json';
 import { getTestProvider } from '../../utils';
+import { getAddress } from 'ethers/lib/utils';
 
 use(evmChai);
 
@@ -83,15 +84,26 @@ describe('dex test', () => {
     await send(swapWithExactSupplyExtrinsic, await alice.getSubstrateAddress());
 
     const txHash = swapWithExactSupplyExtrinsic.hash.toHex();
-    const tx = await evmProvider.getTransactionByHash(swapWithExactSupplyExtrinsic.hash.toHex());
-    console.log(tx);
+    const tx = await evmProvider.getTransactionByHash(txHash);
+    console.log(hexlifyRpcResult(tx));
 
-    const receipt = await evmProvider.getTXReceiptByHash(swapWithExactSupplyExtrinsic.hash.toHex());
+    const receipt = await evmProvider.getTXReceiptByHash(txHash);
     console.log(receipt);
+
+    const aliceEvmAddress = (await alice.getAddress()).toLowerCase();
+    expect(hexlifyRpcResult(tx)).to.contain({
+      hash: txHash,
+      from: aliceEvmAddress,
+      to: hexlifyRpcResult(TokenA.address),
+      // gasPrice: '0x8acaa7f7df',
+      gas: '0x200b20',
+      input: '0x',
+      value: '0x'
+    });
 
     expect(hexlifyRpcResult(receipt)).deep.eq({
       to: hexlifyRpcResult(TokenA.address),
-      from: hexlifyRpcResult(tx.from),
+      from: aliceEvmAddress,
       contractAddress: null,
       transactionIndex: hexlifyRpcResult(tx.transactionIndex),
       gasUsed: hexlifyRpcResult(receipt.gasUsed),

--- a/examples/waffle/e2e/test/dex.test.ts
+++ b/examples/waffle/e2e/test/dex.test.ts
@@ -95,7 +95,6 @@ describe('dex test', () => {
       hash: txHash,
       from: aliceEvmAddress,
       to: hexlifyRpcResult(TokenA.address),
-      // gasPrice: '0x8acaa7f7df',
       gas: '0x200b20',
       input: '0x',
       value: '0x'


### PR DESCRIPTION
## Change
fixed `to` in `getTxByHash`, for non-evm extrinsics, we can't parse `to` from extrinsic. Fortunately we already parsed `to` from txReceipt, so we can use it directly

## Test
- added tests to make sure `getTxByHash` returns correct result for dex.swap extrinsic