### PR TITLE
more standard filter for `eth_getLogs` and `eth_subscribe`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -94,3 +94,5 @@ lib
 
 # Prettier reformats code blocks inside Markdown, which affects rendered output
 *.md
+
+eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts

--- a/eth-providers/src/__tests__/logs.test.ts
+++ b/eth-providers/src/__tests__/logs.test.ts
@@ -32,11 +32,58 @@ describe('filterLog', () => {
     ...partialLog
   };
 
-  const log3 = {
-    address: addr3,
-    topics: [topic3],
-    ...partialLog
-  };
+  const goodAddrFilter2 = [
+    [],
+    addr2,
+    addr2.toUpperCase(),
+    [addr2],
+    [addr2, addr2],
+    [addr2, addr1],
+    [addr2.toLowerCase(), addr1]
+  ];
+
+  const badAddrFilter2 = [addr1, [addr1], [addr3, addr1], addr1.toUpperCase(), [addr3.toLowerCase(), addr1]];
+
+  const goodTopicsFilter1 = [
+    [],
+    [null],
+    [[]],
+    [[], null, [], null],
+    [[], null, [], null, 'overflowwwwwwwww', 'overflowwwwwwwww', 'overflowwwwwwwww'],
+    [topic1],
+    [[topic1]],
+    [[topic2, topic1, 'xxxxx']],
+    [topic1.toUpperCase()],
+    [topic1, null]
+  ];
+
+  const badTopicsFilter1 = [[topic2], [topic1, topic2], [null, [topic1]], [null, [topic2]]];
+
+  const goodTopicsFilter2 = [
+    [],
+    [null],
+    [[]],
+    [[], null, [], null],
+    [null, null, null],
+    [[], null, [], null, 'overflowwwwwwwww', 'overflowwwwwwwww', 'overflowwwwwwwww'],
+    [topic1],
+    [topic1, topic2.toUpperCase(), null, [], 'overflowwwwwwwww'],
+    [topic1.toUpperCase(), topic2, topic3],
+    [null, topic2, topic3],
+    [[topic2, topic1, 'xxxxx'], null, topic3, [], 'overflowwwwwwwww'],
+    [topic1.toUpperCase(), [topic2, topic1, 'xxxxx'], [], [], [], []],
+    [null, topic2, [topic3], []],
+    [[topic2, topic1, 'xxxxx'], null, [topic3], []]
+  ];
+
+  const badTopicsFilter2 = [
+    [topic3],
+    [[topic3]],
+    [[topic3], null, []],
+    [topic1, topic3],
+    [null, ['xxxxx']],
+    [null, null, null, ['xxxxx']]
+  ];
 
   it('when no filter', () => {
     expect(filterLog(log1, {})).to.equal(true);
@@ -44,50 +91,56 @@ describe('filterLog', () => {
   });
 
   it('filter by address', () => {
-    expect(filterLog(log1, { address: addr1 })).to.equal(true);
-    expect(filterLog(log1, { address: [addr1] })).to.equal(true);
-    expect(filterLog(log1, { address: [addr2, addr1] })).to.equal(true);
-    expect(filterLog(log1, { address: addr1.toUpperCase() })).to.equal(true);
-    expect(filterLog(log1, { address: [addr2.toLowerCase(), addr1] })).to.equal(true);
+    for (const address of goodAddrFilter2) {
+      expect(filterLog(log2, { address })).to.equal(true);
+    }
 
-    expect(filterLog(log3, { address: addr1 })).to.equal(false);
-    expect(filterLog(log3, { address: [addr1] })).to.equal(false);
-    expect(filterLog(log3, { address: [addr2, addr1] })).to.equal(false);
+    for (const address of badAddrFilter2) {
+      expect(filterLog(log2, { address })).to.equal(false);
+    }
   });
 
   it('filter by topics', () => {
-    expect(filterLog(log1, { topics: [topic1] })).to.equal(true);
-    expect(filterLog(log1, { topics: [topic1, topic2] })).to.equal(true);
-    expect(filterLog(log1, { topics: [null, [topic1], [topic2], null] })).to.equal(true);
+    for (const topics of goodTopicsFilter1) {
+      expect(filterLog(log1, { topics })).to.equal(true);
+    }
 
-    expect(filterLog(log1, { topics: [topic1.toUpperCase()] })).to.equal(true);
-    expect(filterLog(log1, { topics: [topic1, topic2.toLowerCase()] })).to.equal(true);
-    expect(filterLog(log1, { topics: [null, [topic1.toUpperCase()], [topic2.toLowerCase()], null] })).to.equal(true);
+    for (const topics of badTopicsFilter1) {
+      expect(filterLog(log1, { topics })).to.equal(false);
+    }
 
-    expect(filterLog(log2, { topics: [topic1] })).to.equal(true);
-    expect(filterLog(log2, { topics: [topic1, topic2] })).to.equal(true);
-    expect(filterLog(log2, { topics: [null, [topic1], [topic2], null] })).to.equal(true);
+    for (const topics of goodTopicsFilter2) {
+      expect(filterLog(log2, { topics })).to.equal(true);
+    }
 
-    expect(filterLog(log3, { topics: [topic1] })).to.equal(false);
-    expect(filterLog(log3, { topics: [topic1, topic2] })).to.equal(false);
-    expect(filterLog(log3, { topics: [null, [topic1], [topic2], null] })).to.equal(false);
+    for (const topics of badTopicsFilter2) {
+      expect(filterLog(log2, { topics })).to.equal(false);
+    }
   });
 
   it('filter by topics and logs', () => {
-    // addr1
-    expect(filterLog(log1, { address: addr1, topics: [topic1] })).to.equal(true);
-    expect(filterLog(log1, { address: addr1.toUpperCase(), topics: [topic1, topic3.toLowerCase()] })).to.equal(true);
-    expect(filterLog(log1, { address: addr1, topics: [null, [topic1.toUpperCase()], [topic2], null] })).to.equal(true);
+    for (const address of goodAddrFilter2) {
+      for (const topics of goodTopicsFilter2) {
+        expect(filterLog(log2, { address, topics })).to.equal(true);
+      }
+    }
 
-    expect(filterLog(log1, { address: addr2, topics: [topic1] })).to.equal(false);
-    expect(filterLog(log1, { address: addr2, topics: [topic1, topic3] })).to.equal(false);
-    expect(filterLog(log1, { address: addr2, topics: [null, [topic1], [topic2], null] })).to.equal(false);
-    expect(filterLog(log1, { address: addr1, topics: [topic2] })).to.equal(false);
-    expect(filterLog(log1, { address: addr1, topics: [null, [topic2], [topic3], null] })).to.equal(false);
+    for (const address of badAddrFilter2) {
+      for (const topics of goodTopicsFilter2) {
+        expect(filterLog(log2, { address, topics })).to.equal(false);
+      }
+    }
 
-    // addr2
-    expect(filterLog(log2, { address: addr2.toLowerCase(), topics: [topic1, topic2.toUpperCase()] })).to.equal(true);
-    expect(filterLog(log2, { address: addr2, topics: [topic2] })).to.equal(true);
-    expect(filterLog(log2, { address: addr1, topics: [topic1, topic2, topic3] })).to.equal(false);
+    for (const address of goodAddrFilter2) {
+      for (const topics of badTopicsFilter2) {
+        expect(filterLog(log2, { address, topics })).to.equal(false);
+      }
+    }
+
+    for (const address of badAddrFilter2) {
+      for (const topics of badTopicsFilter2) {
+        expect(filterLog(log2, { address, topics })).to.equal(false);
+      }
+    }
   });
 });

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -78,7 +78,8 @@ import {
   sendTx,
   throwNotImplemented,
   getEffectiveGasPrice,
-  parseBlockTag
+  parseBlockTag,
+  filterLogByTopics
 } from './utils';
 import { BlockCache, CacheInspect } from './utils/BlockCache';
 import { TransactionReceipt as TransactionReceiptGQL, _Metadata } from './utils/gqlTypes';
@@ -1777,7 +1778,8 @@ export abstract class BaseProvider extends AbstractProvider {
       filter.toBlock = toBlockNumber;
     }
 
-    const filteredLogs = await this.subql.getFilteredLogs(filter);
+    const rawLogs = await this.subql.getFilteredLogs(filter);
+    const filteredLogs = rawLogs.filter((log) => filterLogByTopics(log, filter.topics));
 
     return filteredLogs.map((log) => this.formatter.filterLog(log));
   };

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1778,8 +1778,8 @@ export abstract class BaseProvider extends AbstractProvider {
       filter.toBlock = toBlockNumber;
     }
 
-    const rawLogs = await this.subql.getFilteredLogs(filter);
-    const filteredLogs = rawLogs.filter((log) => filterLogByTopics(log, filter.topics));
+    const subqlLogs = await this.subql.getFilteredLogs(filter); // only filtered by blockNumber and address
+    const filteredLogs = subqlLogs.filter((log) => filterLogByTopics(log, filter.topics));
 
     return filteredLogs.map((log) => this.formatter.filterLog(log));
   };

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -147,7 +147,6 @@ describe('eth_getTransactionReceipt', () => {
 
     let txR = allTxReceipts.find((r) => r.blockNumber === '10');
     let res = await eth_getTransactionReceipt([txR.transactionHash]);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.deep.equal({
       to: '0x0230135fded668a3f7894966b14f42e65da322e4',
       from: ADDRESS_ALICE,
@@ -181,7 +180,6 @@ describe('eth_getTransactionReceipt', () => {
 
     txR = allTxReceipts.find((r) => r.blockNumber === '9');
     res = await eth_getTransactionReceipt([txR.transactionHash]);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.deep.equal({
       to: '0x0230135fded668a3f7894966b14f42e65da322e4',
       from: ADDRESS_ALICE,
@@ -215,7 +213,6 @@ describe('eth_getTransactionReceipt', () => {
 
     txR = allTxReceipts.find((r) => r.blockNumber === '6');
     res = await eth_getTransactionReceipt([txR.transactionHash]);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.deep.equal({
       to: '0x0230135fded668a3f7894966b14f42e65da322e4',
       from: ADDRESS_ALICE,
@@ -250,7 +247,6 @@ describe('eth_getTransactionReceipt', () => {
     // dex.swap with erc20
     txR = allTxReceipts.find((r) => r.blockNumber === '20');
     res = await eth_getTransactionReceipt([txR.transactionHash]);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.deep.equal({
       to: '0x532394de2ca885b7e0306a2e258074cca4e42449',
       from: ADDRESS_ALICE,
@@ -324,13 +320,11 @@ describe('eth_getTransactionReceipt', () => {
 
     /* ---------- invalid hex address ---------- */
     res = await eth_getTransactionReceipt(['0x000']);
-    expect(res.status).to.equal(200);
     expect(res.data.error.code).to.equal(-32602);
     expect(res.data.error.message).to.contain('invalid argument');
 
     /* ---------- hash not found ---------- */
     res = await eth_getTransactionReceipt(['0x7ae069634d1154c0299f7fe1d473cf3d6f06cd9b57182d5319eede35a3a4d776']);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.equal(null);
 
     /* ---------- TODO: pending tx ---------- */
@@ -380,49 +374,39 @@ describe('eth_getLogs', () => {
 
       /* ---------- should return all logs ---------- */
       res = await eth_getLogs([{ ...ALL_BLOCK_RANGE_FILTER }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ fromBlock: 0 }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ fromBlock: -100000, toBlock: BIG_NUMBER }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ fromBlock: -100000, toBlock: BIG_NUMBER_HEX }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ fromBlock: 0, toBlock: 'latest' }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       /* ---------- should return no logs ---------- */
       res = await eth_getLogs([{ fromBlock: 99999 }]);
-      expect(res.status).to.equal(200);
       expect(res.data.result).to.deep.equal([]);
 
       res = await eth_getLogs([{ toBlock: -1 }]);
-      expect(res.status).to.equal(200);
       expect(res.data.result).to.deep.equal([]);
 
       /* ---------- should return partial logs ---------- */
       const from = 9;
       const to = 11;
       res = await eth_getLogs([{ fromBlock: from }]);
-      expect(res.status).to.equal(200);
       expectedLogs = allLogs.filter((l) => l.blockNumber >= from);
       expectLogsEqual(res.data.result, expectedLogs);
 
       res = await eth_getLogs([{ fromBlock: 'earliest', toBlock: to }]);
-      expect(res.status).to.equal(200);
       expectedLogs = allLogs.filter((l) => l.blockNumber <= to);
       expectLogsEqual(res.data.result, expectedLogs);
 
       res = await eth_getLogs([{ fromBlock: from, toBlock: to }]);
-      expect(res.status).to.equal(200);
       expectedLogs = allLogs.filter((l) => l.blockNumber >= from && l.blockNumber <= to);
       expectLogsEqual(res.data.result, expectedLogs);
     });
@@ -435,23 +419,18 @@ describe('eth_getLogs', () => {
 
       /* ---------- should return all logs ---------- */
       res = await eth_getLogs([{ fromBlock: 'earliest' }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ fromBlock: 0 }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ fromBlock: '0x0' }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ fromBlock: '0x00000000' }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ fromBlock: 'earliest', toBlock: 'latest' }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       /* ---------- should return no logs ---------- */
@@ -471,17 +450,14 @@ describe('eth_getLogs', () => {
       const from = 8;
       const to = 10;
       res = await eth_getLogs([{ fromBlock: from, toBlock: 'latest' }]);
-      expect(res.status).to.equal(200);
       expectedLogs = allLogs.filter((l) => l.blockNumber >= from);
       expectLogsEqual(res.data.result, expectedLogs);
 
       res = await eth_getLogs([{ fromBlock: 'earliest', toBlock: to }]);
-      expect(res.status).to.equal(200);
       expectedLogs = allLogs.filter((l) => l.blockNumber <= to);
       expectLogsEqual(res.data.result, expectedLogs);
 
       res = await eth_getLogs([{ fromBlock: from, toBlock: to }]);
-      expect(res.status).to.equal(200);
       expectedLogs = allLogs.filter((l) => l.blockNumber >= from && l.blockNumber <= to);
       expectLogsEqual(res.data.result, expectedLogs);
     });
@@ -494,15 +470,12 @@ describe('eth_getLogs', () => {
 
       /* ---------- should return all logs ---------- */
       res = await eth_getLogs([{ topics: [], ...ALL_BLOCK_RANGE_FILTER }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ topics: [[]], ...ALL_BLOCK_RANGE_FILTER }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       res = await eth_getLogs([{ topics: [null, [], null, [], 'hahahahaha', 'hohoho'], ...ALL_BLOCK_RANGE_FILTER }]);
-      expect(res.status).to.equal(200);
       expectLogsEqual(res.data.result, allLogs);
 
       /* ---------- should return no logs ---------- */
@@ -515,26 +488,22 @@ describe('eth_getLogs', () => {
         expectedLogs = allLogs.filter(
           (l) => log.topics.length === l.topics.length && log.topics.every((t, i) => l.topics[i] === t)
         );
-        expect(res.status).to.equal(200);
         expectLogsEqual(res.data.result, expectedLogs);
 
         res = await eth_getLogs([{ topics: [log.topics[0]], ...ALL_BLOCK_RANGE_FILTER }]);
         expectedLogs = allLogs.filter((l) => l.topics[0] === log.topics[0]);
-        expect(res.status).to.equal(200);
         expectLogsEqual(res.data.result, expectedLogs);
 
         res = await eth_getLogs([
           { topics: [['ooo', log.topics[0], 'xxx', 'yyy'], null, []], ...ALL_BLOCK_RANGE_FILTER }
         ]);
         expectedLogs = allLogs.filter((l) => l.topics[0] === log.topics[0]);
-        expect(res.status).to.equal(200);
         expectLogsEqual(res.data.result, expectedLogs);
 
         res = await eth_getLogs([
           { topics: [...new Array(log.topics.length - 1).fill(null), log.topics.at(-1)], ...ALL_BLOCK_RANGE_FILTER }
         ]);
         expectedLogs = allLogs.filter((l) => l.topics[log.topics.length - 1] === log.topics.at(-1));
-        expect(res.status).to.equal(200);
         expectLogsEqual(res.data.result, expectedLogs);
       }
     });
@@ -547,78 +516,53 @@ describe('eth_getLogs', () => {
       for (const log of allLogsFromSubql) {
         const res = await eth_getLogs([{ blockHash: log.blockHash }]);
         const expectedLogs = allLogs.filter((l) => parseInt(l.blockNumber) === parseInt(log.blockNumber));
-        expect(res.status).to.equal(200);
         expectLogsEqual(res.data.result, expectedLogs);
       }
     });
   });
 
   describe('filter by multiple params', () => {
-    let genesisHash: string;
-    let api: ApiPromise;
-
-    before('prepare common variables', async () => {
-      const endpoint = process.env.ENDPOINT_URL || 'ws://127.0.0.1:9944';
-      const wsProvider = new WsProvider(endpoint);
-      api = await ApiPromise.create({ provider: wsProvider });
-
-      genesisHash = api.genesisHash.toHex();
-    });
-
-    after(async () => {
-      await api.disconnect();
-    });
-
     it('returns correct logs', async () => {
       let res;
       let expectedLogs;
       const allLogsFromSubql = await subql.getAllLogs();
 
-      /* -------------------- when there is only 1 target block -------------------- */
+      /* -------------------- match block range -------------------- */
+      expectedLogs = allLogs.filter((l) => parseInt(l.blockNumber) >= 8 && parseInt(l.blockNumber) <= 11);
+      res = await eth_getLogs([{ fromBlock: 8, toBlock: 11, topics: [[], null, []] }]);
+      expectLogsEqual(res.data.result, expectedLogs);
+
+      expectedLogs = allLogs.filter((l) => parseInt(l.blockNumber) <= 15);
+      res = await eth_getLogs([{ fromBlock: 'earliest', toBlock: 15, topics: [[], null, []] }]);
+      expectLogsEqual(res.data.result, expectedLogs);
+
       for (const log of allLogsFromSubql) {
-        // when found
-        const expectedLogs = allLogs.filter((l) => parseInt(l.blockNumber) === parseInt(log.blockNumber));
-
-        res = await eth_getLogs([{ blockHash: log.blockHash, topics: log.topics }]);
-        expect(res.status).to.equal(200);
+        /* -------------------- match blockhash -------------------- */
+        expectedLogs = allLogs.filter((l) => parseInt(l.blockNumber) === parseInt(log.blockNumber));
+        res = await eth_getLogs([{ blockHash: log.blockHash, topics: [[], null, []] }]);
         expectLogsEqual(res.data.result, expectedLogs);
 
-        res = await eth_getLogs([{ blockHash: log.blockHash, topics: [log.topics[0]] }]);
-        expect(res.status).to.equal(200);
+        /* -------------------- match first topic -------------------- */
+        expectedLogs = allLogs.filter(
+          (l) => parseInt(l.blockNumber) === parseInt(log.blockNumber) && l.topics[0] === log.topics[0]
+        );
+        res = await eth_getLogs([{ blockHash: log.blockHash, topics: [[log.topics[0], 'xxx'], null, []] }]);
         expectLogsEqual(res.data.result, expectedLogs);
 
-        res = await eth_getLogs([{ blockHash: log.blockHash, topics: [log.topics.at(-1)] }]);
-        expect(res.status).to.equal(200);
+        /* -------------------- match range and topics -------------------- */
+        expectedLogs = allLogs.filter(
+          (l) => parseInt(l.blockNumber) >= 8 && parseInt(l.blockNumber) <= 15 && l.topics[0] === log.topics[0]
+        );
+        res = await eth_getLogs([{ fromBlock: 8, toBlock: 15, topics: [['xxx', log.topics[0]]] }]);
         expectLogsEqual(res.data.result, expectedLogs);
 
-        // when not found
-        res = await eth_getLogs([{ blockHash: log.blockHash, topics: log.topics, address: '0x12345' }]);
-        expect(res.status).to.equal(200);
+        /* -------------------- no match -------------------- */
+        res = await eth_getLogs([{ blockHash: log.blockHash, topics: ['0x12345'] }]);
         expect(res.data.result).to.deep.equal([]);
 
-        res = await eth_getLogs([{ blockHash: log.blockHash, topics: ['0x18189'], address: log.address }]);
-        expect(res.status).to.equal(200);
-        expect(res.data.result).to.deep.equal([]);
-
-        res = await eth_getLogs([{ blockHash: genesisHash, topics: [log.topics.at(-1)], address: log.address }]);
-        expect(res.status).to.equal(200);
+        res = await eth_getLogs([{ blockHash: log.blockHash, topics: [log.topics[0], 'xxx'] }]);
         expect(res.data.result).to.deep.equal([]);
       }
-
-      /* -------------------- when there is a range of target block -------------------- */
-      res = await eth_getLogs([{ fromBlock: 9, toBlock: 10, topics: [log6.topics[1]], address: log6.address }]);
-      expect(res.status).to.equal(200);
-      expectLogsEqual(res.data.result, [log9, log10]);
-
-      res = await eth_getLogs([
-        { fromBlock: 11, toBlock: 'latest', topics: [log11.topics[0]], address: log12.address }
-      ]);
-      expect(res.status).to.equal(200);
-      expectLogsEqual(res.data.result, [log11]);
-
-      res = await eth_getLogs([{ fromBlock: 'earliest', toBlock: 11, topics: [log6.topics[0]] }]);
-      expect(res.status).to.equal(200);
-      expectLogsEqual(res.data.result, [log6, log7, log8, log9, log10]);
     });
   });
 
@@ -628,19 +572,16 @@ describe('eth_getLogs', () => {
 
       /* ---------- invalid tag ---------- */
       res = await eth_getLogs([{ fromBlock: 'polkadot' }]);
-      expect(res.status).to.equal(200);
       expect(res.data.error.code).to.equal(-32602);
       expect(res.data.error.message).to.contain("blocktag should be number | hex string | 'latest' | 'earliest'");
 
       /* ---------- invalid hex string ---------- */
       res = await eth_getLogs([{ toBlock: '0xzzzz' }]);
-      expect(res.status).to.equal(200);
       expect(res.data.error.code).to.equal(-32602);
       expect(res.data.error.message).to.contain("blocktag should be number | hex string | 'latest' | 'earliest'");
 
       /* ---------- invalid params combination ---------- */
       res = await eth_getLogs([{ toBlock: 123, blockHash: '0x12345' }]);
-      expect(res.status).to.equal(200);
       expect(res.data.error.code).to.equal(-32602);
       expect(res.data.error.message).to.contain(
         '`fromBlock` and `toBlock` is not allowed in params when `blockHash` is present'
@@ -648,7 +589,6 @@ describe('eth_getLogs', () => {
 
       /* ---------- invalid blockhash ---------- */
       res = await eth_getLogs([{ blockHash: '0x12345' }]);
-      expect(res.status).to.equal(200);
       expect(res.data.error.code).to.equal(6969);
       expect(res.data.error.message).to.contain('header not found');
     });
@@ -667,7 +607,6 @@ describe('eth_getTransactionByHash', () => {
     const tx4 = allTxReceipts.find((r) => r.blockNumber === '20');
 
     let res = await eth_getTransactionByHash([tx1.transactionHash]);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.deep.equal({
       blockHash: tx1.blockHash,
       blockNumber: '0xa',
@@ -687,7 +626,6 @@ describe('eth_getTransactionByHash', () => {
     });
 
     res = await eth_getTransactionByHash([tx2.transactionHash]);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.deep.equal({
       blockHash: tx2.blockHash,
       blockNumber: '0x9',
@@ -707,7 +645,6 @@ describe('eth_getTransactionByHash', () => {
     });
 
     res = await eth_getTransactionByHash([tx3.transactionHash]);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.deep.equal({
       blockHash: tx3.blockHash,
       blockNumber: '0x6',
@@ -728,7 +665,6 @@ describe('eth_getTransactionByHash', () => {
 
     // dex.swap with erc20 tokens
     res = await eth_getTransactionByHash([tx4.transactionHash]);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.deep.equal({
       blockHash: tx4.blockHash,
       blockNumber: '0x14',
@@ -777,13 +713,11 @@ describe('eth_getTransactionByHash', () => {
 
     /* ---------- invalid hex address ---------- */
     res = await eth_getTransactionByHash(['0x000']);
-    expect(res.status).to.equal(200);
     expect(res.data.error.code).to.equal(-32602);
     expect(res.data.error.message).to.contain('invalid argument');
 
     /* ---------- hash not found ---------- */
     res = await eth_getTransactionByHash(['0x7ae069634d1154c0299f7fe1d473cf3d6f06cd9b57182d5319eede35a3a4d776']);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.equal(null);
   });
 });
@@ -793,7 +727,6 @@ describe('eth_accounts', () => {
 
   it('returns empty array', async () => {
     const res = await eth_accounts([]);
-    expect(res.status).to.equal(200);
     expect(res.data.result).to.deep.equal([]);
   });
 });
@@ -887,7 +820,6 @@ describe('eth_sendRawTransaction', () => {
         expect(parsedTx.maxFeePerGas).equal(undefined);
 
         const res = await eth_sendRawTransaction([rawTx]);
-        expect(res.status).to.equal(200);
         expect(res.data.error?.message).to.equal(undefined); // for TX error RPC will still return 200
 
         const calculatedTxFee = await getCalculatedTxFee(res.data.result);
@@ -927,7 +859,6 @@ describe('eth_sendRawTransaction', () => {
         expect(parsedTx.gasPrice).equal(null);
 
         const res = await eth_sendRawTransaction([rawTx]);
-        expect(res.status).to.equal(200);
         expect(res.data.error?.message).to.equal(undefined); // for TX error RPC will still return 200
 
         const calculatedTxFee = await getCalculatedTxFee(res.data.result);
@@ -973,7 +904,6 @@ describe('eth_sendRawTransaction', () => {
         expect(parsedTx.maxFeePerGas).equal(undefined);
 
         const res = await eth_sendRawTransaction([rawTx]);
-        expect(res.status).to.equal(200);
         expect(res.data.error?.message).to.equal(undefined); // for TX error RPC will still return 200
 
         const calculatedTxFee = await getCalculatedTxFee(res.data.result);
@@ -1017,7 +947,6 @@ describe('eth_sendRawTransaction', () => {
         const rawTx = await wallet1.signTransaction(transferTX);
 
         const res = await eth_sendRawTransaction([rawTx]);
-        expect(res.status).to.equal(200);
         expect(res.data.error?.message).to.equal(undefined); // for TX error RPC will still return 200
 
         const calculatedTxFee = await getCalculatedTxFee(res.data.result); // this has to come first
@@ -1053,7 +982,6 @@ describe('eth_sendRawTransaction', () => {
         const parsedTx = parseTransaction(rawTx);
 
         const res = await eth_sendRawTransaction([rawTx]);
-        expect(res.status).to.equal(200);
         expect(res.data.error?.message).to.equal(undefined); // for TX error RPC will still return 200
 
         const calculatedTxFee = await getCalculatedTxFee(res.data.result); // this has to come first
@@ -1094,7 +1022,6 @@ describe('eth_sendRawTransaction', () => {
         const parsedTx = parseTransaction(rawTx);
 
         const res = await eth_sendRawTransaction([rawTx]);
-        expect(res.status).to.equal(200);
         expect(res.data.error?.message).to.equal(undefined); // for TX error RPC will still return 200
 
         const calculatedTxFee = await getCalculatedTxFee(res.data.result); // this has to come first
@@ -1164,7 +1091,6 @@ describe('eth_sendRawTransaction', () => {
         const rawTx = await wallet1.signTransaction(transferTX);
 
         const res = await eth_sendRawTransaction([rawTx]);
-        expect(res.status).to.equal(200);
         expect(res.data.error?.message).to.equal(undefined); // for TX error RPC will still return 200
 
         const calculatedTxFee = await getCalculatedTxFee(res.data.result, false); // this has to come first
@@ -1204,7 +1130,6 @@ describe('eth_sendRawTransaction', () => {
         const parsedTx = parseTransaction(rawTx);
 
         const res = await eth_sendRawTransaction([rawTx]);
-        expect(res.status).to.equal(200);
         expect(res.data.error?.message).to.equal(undefined); // for TX error RPC will still return 200
 
         const calculatedTxFee = await getCalculatedTxFee(res.data.result, false); // this has to come first
@@ -1243,7 +1168,6 @@ describe('eth_sendRawTransaction', () => {
         // const rawTx = serializeTransaction(transferTX, sig);
         // const parsedTx = parseTransaction(rawTx);
         // const res = await eth_sendRawTransaction([rawTx]);
-        // expect(res.status).to.equal(200);
         // expect(res.data.error?.message).to.equal(undefined); // for TX error RPC will still return 200
         // const txHash = res.data.result;
         // const { gasUsed, effectiveGasPrice } = (await eth_getTransactionReceipt([txHash])).data.result;
@@ -1424,7 +1348,6 @@ describe('eth_getEthGas', () => {
   it('throws error when params are not valid', async () => {
     const res = await eth_getEthGas([{ anyParam: 12345 }]);
 
-    expect(res.status).to.equal(200);
     expect(res.data.error.code).to.equal(-32602);
     expect(res.data.error.message).to.contain(`parameter can only be 'storageLimit' | 'gasLimit' | 'validUntil'`);
   });

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -528,31 +528,41 @@ describe('eth_getLogs', () => {
       const allLogsFromSubql = await subql.getAllLogs();
 
       /* -------------------- match block range -------------------- */
-      expectedLogs = allLogs.filter((l) => parseInt(l.blockNumber) >= 8 && parseInt(l.blockNumber) <= 11);
+      expectedLogs = allLogs.filter((l) => (
+        parseInt(l.blockNumber) >= 8 &&
+        parseInt(l.blockNumber) <= 11
+      ));
       res = await eth_getLogs([{ fromBlock: 8, toBlock: 11, topics: [[], null, []] }]);
       expectLogsEqual(res.data.result, expectedLogs);
 
-      expectedLogs = allLogs.filter((l) => parseInt(l.blockNumber) <= 15);
-      res = await eth_getLogs([{ fromBlock: 'earliest', toBlock: 15, topics: [[], null, []] }]);
+      expectedLogs = allLogs.filter((l) => (
+        parseInt(l.blockNumber) <= 15
+      ));
+      res = await eth_getLogs([{ fromBlock: "earliest", toBlock: 15, topics: [[], null, []] }]);
       expectLogsEqual(res.data.result, expectedLogs);
 
       for (const log of allLogsFromSubql) {
         /* -------------------- match blockhash -------------------- */
-        expectedLogs = allLogs.filter((l) => parseInt(l.blockNumber) === parseInt(log.blockNumber));
+        expectedLogs = allLogs.filter((l) => (
+          parseInt(l.blockNumber) === parseInt(log.blockNumber)
+        ));
         res = await eth_getLogs([{ blockHash: log.blockHash, topics: [[], null, []] }]);
         expectLogsEqual(res.data.result, expectedLogs);
 
         /* -------------------- match first topic -------------------- */
-        expectedLogs = allLogs.filter(
-          (l) => parseInt(l.blockNumber) === parseInt(log.blockNumber) && l.topics[0] === log.topics[0]
-        );
+        expectedLogs = allLogs.filter((l) => (
+          parseInt(l.blockNumber) === parseInt(log.blockNumber) &&
+          l.topics[0] === log.topics[0]
+        ));
         res = await eth_getLogs([{ blockHash: log.blockHash, topics: [[log.topics[0], 'xxx'], null, []] }]);
         expectLogsEqual(res.data.result, expectedLogs);
 
         /* -------------------- match range and topics -------------------- */
-        expectedLogs = allLogs.filter(
-          (l) => parseInt(l.blockNumber) >= 8 && parseInt(l.blockNumber) <= 15 && l.topics[0] === log.topics[0]
-        );
+        expectedLogs = allLogs.filter((l) => (
+          parseInt(l.blockNumber) >= 8 &&
+          parseInt(l.blockNumber) <= 15 &&
+          l.topics[0] === log.topics[0]
+        ));
         res = await eth_getLogs([{ fromBlock: 8, toBlock: 15, topics: [['xxx', log.topics[0]]] }]);
         expectLogsEqual(res.data.result, expectedLogs);
 


### PR DESCRIPTION
## Change
upgrades log filter to use [more standard bloom filter](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newfilter), which allows nested filter.

**affected RPCs**
- `eth_getLogs`: block number and address filtering is by subql, then topics filtering is handled by `filterLogByTopics`
- `eth_subscribe` for logs: it only supports filtering with address and topics, which is handled by `filterLog` method, which performs both `filterLogByTopics` and `filterLogByAddress`

## Test
add new tests and modified prev ones to reflect the new filter interface.