### PR TITLE
Rich Mode

### DIFF
--- a/eth-providers/src/consts.ts
+++ b/eth-providers/src/consts.ts
@@ -59,6 +59,12 @@ export const SAFE_MODE_WARNING_MSG = `
   ---------------------------------------------------------------------
 `;
 
+export const RICH_MODE_WARNING_MSG = `
+  ------------------------------------------- WARNING --------------------------------------------
+  🔥 RichMode is ON, default gas params are much bigger than normal in favor of testing contracts!
+  ------------------------------------------------------------------------------------------------
+`;
+
 export const CACHE_SIZE_WARNING = `
   ------------------- WARNING -------------------
   Max cached blocks is big, please be cautious!

--- a/eth-rpc-adapter/README.md
+++ b/eth-rpc-adapter/README.md
@@ -44,6 +44,7 @@ note that docker image might not be most up-to-date. Latest image can be found [
 | SAFE_MODE          | -s, --safe               | 0                   | if enabled, TX and logs can only be found after they are finalized                                      |
 | FORWARD_MODE          | -f, --forward         | 0                   | if enabled, the Substrate rpc will be forwarded to the Substrate node                                  |
 | LOCAL_MODE         | -l, --local              | 0                   | enable this mode when testing with locally running mandala                                              |
+| RICH_MODE         | -r, --rich              | 0                   | if enabled, default gas params is big enough for most contract deployment and calls                                              |
 | VERBOSE            | -v, --verbose            | 1                   | print some extra info                                                                                   |
 
 NOTE: Please don't mix using ENV and flags. `.env.sample` contains an example envs. 

--- a/eth-rpc-adapter/src/server.ts
+++ b/eth-rpc-adapter/src/server.ts
@@ -14,6 +14,7 @@ export async function start(): Promise<void> {
   const provider = EvmRpcProvider.from(opts.endpoints.split(','), {
     safeMode: opts.safeMode,
     localMode: opts.localMode,
+    richMode: opts.richMode,
     verbose: opts.verbose,
     subqlUrl: opts.subqlUrl,
     maxBlockCacheSize: opts.maxBlockCacheSize,
@@ -65,6 +66,7 @@ export async function start(): Promise<void> {
   safe mode       : ${opts.safeMode}
   local mode      : ${opts.localMode}
   forward mode    : ${opts.forwardMode}
+  rich mode       : ${opts.richMode}
   verbose         : ${opts.verbose}
   --------------------------------------------
   `);

--- a/eth-rpc-adapter/src/utils/utils.ts
+++ b/eth-rpc-adapter/src/utils/utils.ts
@@ -39,6 +39,7 @@ export interface ServerOpts {
   safeMode: boolean;
   localMode: boolean;
   forwardMode: boolean;
+  richMode: boolean;
   verbose: boolean;
 }
 
@@ -64,7 +65,7 @@ const DEFAULT_SERVER_ARGS: ServerArgs = {
 
 export const parseOptions = (): ServerOpts => {
   const argv = minimist<ServerArgs>(process.argv.slice(2), { default: DEFAULT_SERVER_ARGS });
-  const { e, h, w, s, l, f, v, endpoint, subql, safe, local, forward, verbose } = argv;
+  const { e, h, w, s, l, f, r, v, endpoint, subql, safe, local, forward, rich, verbose } = argv;
 
   dotenv.config();
   const {
@@ -78,6 +79,7 @@ export const parseOptions = (): ServerOpts => {
     SAFE_MODE,
     LOCAL_MODE,
     FORWARD_MODE,
+    RICH_MODE,
     VERBOSE
   } = process.env;
 
@@ -92,6 +94,7 @@ export const parseOptions = (): ServerOpts => {
     safeMode: !!Number(SAFE_MODE || s || safe),
     localMode: !!Number(LOCAL_MODE || local || l),
     forwardMode: !!Number(FORWARD_MODE || f || forward),
+    richMode: !!Number(RICH_MODE || r || rich),
     verbose: !!Number(VERBOSE || verbose || v)
   };
 };

--- a/eth-rpc-adapter/src/utils/utils.ts
+++ b/eth-rpc-adapter/src/utils/utils.ts
@@ -25,6 +25,7 @@ export interface ServerArgs {
   safe: number | boolean;
   local: number | boolean;
   forward: number | boolean;
+  rich: number | boolean;
   verbose: number | boolean;
 }
 
@@ -60,6 +61,7 @@ const DEFAULT_SERVER_ARGS: ServerArgs = {
   forward: 0,
   safe: 0,
   local: 0,
+  rich: 0,
   verbose: 1
 };
 


### PR DESCRIPTION
## Change
added a rich mode for more convenient local contract testing. In this mode gas params will default to large amount so all operations should not require at gas overrides anymore.

This is especially helpful for large contract tests with hardhat.

## Test
Tested some local contract deployments without gas overrides:
- when rich mode is enabled, contract creation succeed
- when rich mode disabled, contract creation will fail by `Error: evm.OutOfStorage: Storage usage exceeds storage limit`