### PR TITLE
logs and error handling polish

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1119,7 +1119,6 @@ export abstract class BaseProvider extends AbstractProvider {
     // check excuted error
     const callRequest: CallRequest = {
       from: ethTx.from,
-      // @TODO Support create
       to: ethTx.to,
       gasLimit: gasLimit,
       storageLimit: storageLimit,
@@ -1128,7 +1127,7 @@ export abstract class BaseProvider extends AbstractProvider {
       accessList: ethTx.accessList
     };
 
-    await (this.api.rpc as any).evm.call(callRequest);
+    await this.api.rpc.evm.call(callRequest);
 
     const extrinsic = this.api.tx.evm.ethCall(
       ethTx.to ? { Call: ethTx.to } : { Create: null },
@@ -1155,15 +1154,6 @@ export abstract class BaseProvider extends AbstractProvider {
       nonce: ethTx.nonce,
       tip
     });
-
-    logger.debug(
-      {
-        evmAddr: ethTx.from,
-        address: subAddr,
-        hash: extrinsic.hash.toHex()
-      },
-      'sending raw transaction'
-    );
 
     return {
       extrinsic,

--- a/eth-providers/src/utils/handleTxResponse.ts
+++ b/eth-providers/src/utils/handleTxResponse.ts
@@ -3,7 +3,6 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { hexToString } from '@polkadot/util';
 
 // https://ethereum.stackexchange.com/questions/84545/how-to-get-reason-revert-using-web3-eth-call
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export function decodeMessage(reason: any, code?: string): string {
   const reasonString = JSON.stringify(reason).toLowerCase();
 

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -46,7 +46,7 @@ export interface HealthData {
 export const sleep = (interval = 1000): Promise<null> =>
   new Promise((resolve) => setTimeout(() => resolve(null), interval));
 
-export const promiseWithTimeout = <T>(value: any, interval = 1000) => {
+export const promiseWithTimeout = <T = any>(value: any, interval = 1000): Promise<T> => {
   let timeoutHandle: any;
   const timeoutPromise = new Promise((resolve) => {
     timeoutHandle = setTimeout(() => resolve(null), interval);

--- a/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -10,14 +10,18 @@ import { Wallet } from '@ethersproject/wallet';
 import { BigNumber } from '@ethersproject/bignumber';
 import { parseUnits, Interface } from 'ethers/lib/utils';
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import axios from 'axios';
 import { expect } from 'chai';
-import dotenv from 'dotenv';
+import {
+  bigIntDiff,
+  rpcGet,
+  PUBLIC_MANDALA_RPC_URL,
+  RPC_URL,
+  SUBQL_URL,
+} from './utils';
 import {
   ADDRESS_ALICE,
   evmAccounts,
   allLogs,
-  log12,
   log6,
   log9,
   log12,
@@ -39,29 +43,7 @@ import {
   log22_1
 } from './consts';
 
-export const bigIntDiff = (x: bigint, y: bigint): bigint => {
-  return x > y ? x - y : y - x;
-};
-
-dotenv.config();
-
-const PUBLIC_MANDALA_RPC_URL = process.env.PUBLIC_MANDALA_RPC_URL || 'http://127.0.0.1:8546';
-const RPC_URL = process.env.RPC_URL || 'http://127.0.0.1:8545';
-const SUBQL_URL = process.env.SUBQL_URL || 'http://127.0.0.1:3001';
-
 const subql = new SubqlProvider(SUBQL_URL);
-
-const rpcGet =
-  (method: string, url?: string = RPC_URL) =>
-  (params: any): any =>
-    axios.get(url, {
-      data: {
-        id: 0,
-        jsonrpc: '2.0',
-        method,
-        params
-      }
-    });
 
 export const logsEq = (a: Log[], b: Log[]): boolean =>
   a.length === b.length &&

--- a/eth-rpc-adapter/src/__tests__/e2e/errors.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/errors.test.ts
@@ -1,0 +1,114 @@
+import { BigNumber, Wallet } from 'ethers';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { rpcGet, RPC_URL } from './utils';
+import axios from 'axios';
+import { expect } from 'chai';
+
+const eth_getEthGas = rpcGet('eth_getEthGas', RPC_URL);
+const eth_blockNumber = rpcGet('eth_blockNumber', RPC_URL);
+const eth_sendRawTransaction = rpcGet('eth_sendRawTransaction', RPC_URL);
+const eth_getTransactionReceipt = rpcGet('eth_getTransactionReceipt', RPC_URL);
+const eth_chainId = rpcGet('eth_chainId', RPC_URL);
+
+describe('errors', () => {
+  const POOR_ACCOUNT = '0xa872f6cbd25a0e04a08b1e21098017a9e6194d101d75e13111f71410c59cd570';
+  const poorWallet = new Wallet(POOR_ACCOUNT, new JsonRpcProvider(RPC_URL));
+
+  it('invalid request', async () => {
+    const id = 12345;
+
+    const res = await axios.get(RPC_URL, {
+      data: {
+        id,
+        methodddddddd: 'vdhgkjshdbfksdh',
+        jsonrpc: '2.0'
+      }
+    });
+
+    expect(res.data).to.deep.equal({
+      id,
+      jsonrpc: '2.0',
+      error: {
+        code: -32600,
+        data: { id, method: null, params: null },
+        message: 'invalid json request'
+      }
+    });
+  });
+
+  // TODO: after the banned pool is disabled in dev mode, mayve change the endpoint to public one? or manually setup the banned pool time to positive to enable it
+  it('tx banned', async () => {
+    const [gasRes, chainIdRes, nonce] = await Promise.all([
+      eth_getEthGas(),
+      eth_chainId(),
+      poorWallet.getTransactionCount('pending')
+    ]);
+
+    const chainId = Number(chainIdRes.data.result);
+    const gas = gasRes.data.result;
+
+    const tx = {
+      to: poorWallet.address,
+      data: '0x',
+      value: 0,
+      chainId,
+      nonce,
+      ...gas
+    };
+    const rawTx = await poorWallet.signTransaction(tx);
+
+    let res = await eth_sendRawTransaction([rawTx]);
+    expect(res.data).to.deep.equal({
+      id: 0,
+      jsonrpc: '2.0',
+      error: {
+        code: -32603,
+        message:
+          'internal JSON-RPC error [1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low]. More info: https://evmdocs.acala.network/reference/common-errors'
+      }
+    });
+
+    res = await eth_sendRawTransaction([rawTx]);
+    expect(res.data).to.deep.equal({
+      id: 0,
+      jsonrpc: '2.0',
+      error: {
+        code: -32603,
+        message:
+          'internal JSON-RPC error [1012: Transaction is temporarily banned]. More info: https://evmdocs.acala.network/reference/common-errors'
+      }
+    });
+  });
+
+  it('internal json rpc error', async () => {
+    const [gasRes, chainIdRes, nonce] = await Promise.all([
+      eth_getEthGas(),
+      eth_chainId(),
+      poorWallet.getTransactionCount('pending')
+    ]);
+
+    const chainId = Number(chainIdRes.data.result);
+    const gas = gasRes.data.result;
+
+    const tx = {
+      to: poorWallet.address,
+      data: '0x',
+      value: 123,
+      chainId,
+      nonce,
+      ...gas
+    };
+    const rawTx = await poorWallet.signTransaction(tx);
+    const res = await eth_sendRawTransaction([rawTx]);
+
+    expect(res.data).to.deep.equal({
+      id: 0,
+      jsonrpc: '2.0',
+      error: {
+        code: -32603,
+        message:
+          'internal JSON-RPC error [evm.InvalidDecimals: Invalid decimals]. More info: https://evmdocs.acala.network/reference/common-errors'
+      }
+    });
+  });
+});

--- a/eth-rpc-adapter/src/__tests__/e2e/utils.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/utils.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+export const rpcGet =
+  (method: string, url?: string = RPC_URL) =>
+  (params: any[] = []): any =>
+    axios.get(url, {
+      data: {
+        id: 0,
+        jsonrpc: '2.0',
+        method,
+        params
+      }
+    });
+
+export const bigIntDiff = (x: bigint, y: bigint): bigint => {
+  return x > y ? x - y : y - x;
+};
+
+export const PUBLIC_MANDALA_RPC_URL = process.env.PUBLIC_MANDALA_RPC_URL || 'http://127.0.0.1:8546';
+export const RPC_URL = process.env.RPC_URL || 'http://127.0.0.1:8545';
+export const SUBQL_URL = process.env.SUBQL_URL || 'http://127.0.0.1:3001';

--- a/eth-rpc-adapter/src/__tests__/e2e/utils.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/utils.ts
@@ -1,7 +1,11 @@
 import axios from 'axios';
 
+export const PUBLIC_MANDALA_RPC_URL = process.env.PUBLIC_MANDALA_RPC_URL || 'http://127.0.0.1:8546';
+export const RPC_URL = process.env.RPC_URL || 'http://127.0.0.1:8545';
+export const SUBQL_URL = process.env.SUBQL_URL || 'http://127.0.0.1:3001';
+
 export const rpcGet =
-  (method: string, url?: string = RPC_URL) =>
+  (method: string, url: string = RPC_URL) =>
   (params: any[] = []): any =>
     axios.get(url, {
       data: {
@@ -15,7 +19,3 @@ export const rpcGet =
 export const bigIntDiff = (x: bigint, y: bigint): bigint => {
   return x > y ? x - y : y - x;
 };
-
-export const PUBLIC_MANDALA_RPC_URL = process.env.PUBLIC_MANDALA_RPC_URL || 'http://127.0.0.1:8546';
-export const RPC_URL = process.env.RPC_URL || 'http://127.0.0.1:8545';
-export const SUBQL_URL = process.env.SUBQL_URL || 'http://127.0.0.1:3001';

--- a/eth-rpc-adapter/src/errors.ts
+++ b/eth-rpc-adapter/src/errors.ts
@@ -31,9 +31,21 @@ export class InvalidRequest extends JSONRPCError {
   }
 }
 
+export class BatchSizeError extends JSONRPCError {
+  constructor(maximumSize: number, actualSize: number) {
+    super('exceeded maximum batch size', -32600, `maximum batch size is ${maximumSize}, but received ${actualSize}`);
+  }
+}
+
 export class MethodNotFound extends JSONRPCError {
   constructor(message: string, data?: any) {
     super(message, -32601, data);
+  }
+}
+
+export class InvalidParams extends JSONRPCError {
+  constructor(message: string, data?: any) {
+    super(message, -32602, data);
   }
 }
 
@@ -45,17 +57,5 @@ export class InternalError extends JSONRPCError {
       }. More info: https://evmdocs.acala.network/reference/common-errors`,
       -32603
     );
-  }
-}
-
-export class InvalidParams extends JSONRPCError {
-  constructor(message: string, data?: any) {
-    super(message, -32602, data);
-  }
-}
-
-export class BatchSizeError extends JSONRPCError {
-  constructor(maximumSize: number, actualSize: number) {
-    super('exceeded maximum batch size', -32600, `maximum batch size is ${maximumSize}, but received ${actualSize}`);
   }
 }

--- a/eth-rpc-adapter/src/errors.ts
+++ b/eth-rpc-adapter/src/errors.ts
@@ -26,20 +26,25 @@ export class JSONRPCError extends Error {
 }
 
 export class InvalidRequest extends JSONRPCError {
-  constructor() {
-    super('invalid json request', -32600);
-  }
-}
-
-export class InternalError extends JSONRPCError {
-  constructor() {
-    super('internal error', -32603);
+  constructor(data?: any) {
+    super('invalid json request', -32600, data);
   }
 }
 
 export class MethodNotFound extends JSONRPCError {
   constructor(message: string, data?: any) {
     super(message, -32601, data);
+  }
+}
+
+export class InternalError extends JSONRPCError {
+  constructor(data?: any) {
+    super(
+      `internal JSON-RPC error ${
+        data && `[${data}]`
+      }. More info: https://evmdocs.acala.network/reference/common-errors`,
+      -32603
+    );
   }
 }
 

--- a/eth-rpc-adapter/src/index.ts
+++ b/eth-rpc-adapter/src/index.ts
@@ -2,6 +2,6 @@ import 'dd-trace/init';
 import { start } from './server';
 
 start().catch((e) => {
-  console.log(e);
+  console.error(e);
   process.exit(1);
 });

--- a/eth-rpc-adapter/src/router.ts
+++ b/eth-rpc-adapter/src/router.ts
@@ -3,7 +3,6 @@ import { Logger as EthLogger } from '@ethersproject/logger';
 import WebSocket from 'ws';
 import { Eip1193Bridge } from './eip1193-bridge';
 import { InternalError, InvalidParams, JSONRPCError, MethodNotFound } from './errors';
-import { logger } from './logger';
 import { RpcForward } from './rpc-forward';
 import { JSONRPCResponse } from './transports/types';
 export class Router {
@@ -20,8 +19,6 @@ export class Router {
       try {
         return { result: await this.#bridge.send(methodName, params, ws) };
       } catch (err: any) {
-        // console.log('!!!!!!!!!!!!!!!!!', typeof err === 'object', err.code, err.message)
-
         if (JSONRPCError.isJSONRPCError(err)) {
           return { error: err.json() };
         }
@@ -53,10 +50,6 @@ export class Router {
             case 1010:
               error = new InternalError(message);
               break;
-
-            // error = new InternalError(`${message}. Usually a transaction identical to this one has recently failed. Please refer to our doc: https://evmdocs.acala.network/reference/common-errors#value-code-23603-data-code-6969-messages-error-1012-invalid-transaction-transaction-is-temporary-ban`); break;
-
-            // error = new InternalError(`${message}. Please refer to our doc: https://evmdocs.acala.network/reference/common-errors#value-code-23603-data-code-6969-messages-error-1010-invalid-transaction-transaction-is-outdated`); break;
 
             default:
               break;

--- a/eth-rpc-adapter/src/router.ts
+++ b/eth-rpc-adapter/src/router.ts
@@ -2,7 +2,7 @@ import { ERROR_PATTERN } from '@acala-network/eth-providers';
 import { Logger as EthLogger } from '@ethersproject/logger';
 import WebSocket from 'ws';
 import { Eip1193Bridge } from './eip1193-bridge';
-import { InvalidParams, JSONRPCError, MethodNotFound } from './errors';
+import { InternalError, InvalidParams, JSONRPCError, MethodNotFound } from './errors';
 import { logger } from './logger';
 import { RpcForward } from './rpc-forward';
 import { JSONRPCResponse } from './transports/types';
@@ -20,30 +20,11 @@ export class Router {
       try {
         return { result: await this.#bridge.send(methodName, params, ws) };
       } catch (err: any) {
+        // console.log('!!!!!!!!!!!!!!!!!', typeof err === 'object', err.code, err.message)
+
         if (JSONRPCError.isJSONRPCError(err)) {
-          return { error: { code: err.code, message: err.message, data: err.data } };
+          return { error: err.json() };
         }
-        if (typeof err === 'object' && err.code) {
-          let error = null;
-
-          if (err.code === EthLogger.errors.INVALID_ARGUMENT) {
-            error = new InvalidParams(err.message);
-          }
-
-          if (err.code === EthLogger.errors.UNSUPPORTED_OPERATION) {
-            error = new InvalidParams(err.message);
-          }
-
-          if (err.code === EthLogger.errors.NOT_IMPLEMENTED) {
-            error = new MethodNotFound(err.message);
-          }
-
-          if (error) {
-            return { error: error.json() };
-          }
-        }
-
-        logger.error({ err, methodName, params }, 'request error');
 
         let message = err.message;
         for (const pattern of ERROR_PATTERN) {
@@ -55,14 +36,39 @@ export class Router {
           }
         }
 
-        return { error: new JSONRPCError(`Error: ${message}`, 6969) };
+        let error = null;
+        if (typeof err === 'object' && err.code) {
+          switch (err.code) {
+            case EthLogger.errors.INVALID_ARGUMENT:
+            case EthLogger.errors.UNSUPPORTED_OPERATION:
+              error = new InvalidParams(message);
+              break;
+
+            case EthLogger.errors.NOT_IMPLEMENTED:
+              error = new InvalidParams(message);
+              break;
+
+            case -32603:
+            case 1012:
+            case 1010:
+              error = new InternalError(message);
+              break;
+
+            // error = new InternalError(`${message}. Usually a transaction identical to this one has recently failed. Please refer to our doc: https://evmdocs.acala.network/reference/common-errors#value-code-23603-data-code-6969-messages-error-1012-invalid-transaction-transaction-is-temporary-ban`); break;
+
+            // error = new InternalError(`${message}. Please refer to our doc: https://evmdocs.acala.network/reference/common-errors#value-code-23603-data-code-6969-messages-error-1010-invalid-transaction-transaction-is-outdated`); break;
+
+            default:
+              break;
+          }
+        }
+
+        return { error: error?.json() || new JSONRPCError(`Error: ${message}`, 6969) };
       }
     } else if (this.#rpcForward && this.#rpcForward.isMethodValid(methodName)) {
       try {
         return { result: await this.#rpcForward.send(methodName, params, ws) };
       } catch (err: any) {
-        logger.error({ err, methodName, params }, 'forward request error');
-
         return { error: new JSONRPCError(err.message, 6969) };
       }
     } else {

--- a/eth-rpc-adapter/src/transports/http.ts
+++ b/eth-rpc-adapter/src/transports/http.ts
@@ -3,7 +3,7 @@ import connect, { HandleFunction } from 'connect';
 import cors from 'cors';
 import http, { ServerOptions } from 'http';
 import ServerTransport from './server-transport';
-import type { JSONRPCRequest, JSONRPCResponse } from './types';
+import type { JSONRPCRequest } from './types';
 import { logger } from '../logger';
 import { errorHandler } from '../middlewares';
 import { BatchSizeError } from '../errors';

--- a/eth-rpc-adapter/src/transports/http.ts
+++ b/eth-rpc-adapter/src/transports/http.ts
@@ -69,11 +69,7 @@ export default class HTTPServerTransport extends ServerTransport {
       }
     }
 
-    if (!(result as JSONRPCResponse).error) {
-      logger.debug(result, 'request completed');
-    } else {
-      logger.error(result, 'request completed');
-    }
+    logger.debug(result, 'request completed');
 
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(result));

--- a/eth-rpc-adapter/src/transports/server-transport.ts
+++ b/eth-rpc-adapter/src/transports/server-transport.ts
@@ -28,10 +28,13 @@ export abstract class ServerTransport {
     };
 
     if (id === null || id === undefined || !method) {
-      logger.error(`invalid json request: id: ${id}, method: ${method}, params: ${params}`);
       return {
         ...res,
-        error: new InvalidRequest().json()
+        error: new InvalidRequest({
+          id: id || null,
+          method: method || null,
+          params: params || null
+        }).json()
       };
     }
 

--- a/eth-rpc-adapter/src/transports/websocket.ts
+++ b/eth-rpc-adapter/src/transports/websocket.ts
@@ -8,7 +8,7 @@ import { BatchSizeError, InvalidRequest } from '../errors';
 import { logger } from '../logger';
 import { errorHandler } from '../middlewares';
 import ServerTransport from './server-transport';
-import type { JSONRPCRequest, JSONRPCResponse } from './types';
+import type { JSONRPCRequest } from './types';
 
 export interface WebSocketServerTransportOptions extends SecureServerOptions {
   middleware: HandleFunction[];

--- a/eth-rpc-adapter/src/transports/websocket.ts
+++ b/eth-rpc-adapter/src/transports/websocket.ts
@@ -132,11 +132,8 @@ export default class WebSocketServerTransport extends ServerTransport {
       result = await super.routerHandler(req, ws);
     }
 
-    if (!(result as JSONRPCResponse).error) {
-      logger.debug(result, 'request completed');
-    } else {
-      logger.error(result, 'request completed');
-    }
+    logger.debug(result, 'request completed');
+
     ws.send(JSON.stringify(result));
   }
 }


### PR DESCRIPTION
## Change
- for the errors that we don't need to pay attention to, such as json rpc errors, we won't log them as error, instead the error msg will be included in the json rpc response, which is logged as debug
- did some polish of the error msg in the response so that it includes more details and link to our doc

## Test
added some new tests for a couple common error cases such as invalid request, insufficient balance, tx banned, and internal json rpc error.

## Todo
there are still some error msg from polkadot api that can't be suppressed https://github.com/polkadot-js/api/issues/3184
but we can filter out them in datadog