### PR TITLE
Narrow ethers imports

### DIFF
--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -23,6 +23,7 @@
     "@ethersproject/bignumber": "~5.5.0",
     "@ethersproject/bytes": "~5.5.0",
     "@ethersproject/contracts": "~5.5.0",
+    "@ethersproject/keccak256": "~5.5.0",
     "@ethersproject/logger": "~5.5.0",
     "@ethersproject/networks": "~5.5.0",
     "@ethersproject/properties": "~5.5.0",

--- a/eth-providers/src/utils/transactionReceiptHelper.ts
+++ b/eth-providers/src/utils/transactionReceiptHelper.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { hexValue, isHexString } from '@ethersproject/bytes';
+import { keccak256 } from '@ethersproject/keccak256';
 import { Logger } from '@ethersproject/logger';
 import { Formatter, TransactionReceipt } from '@ethersproject/providers';
-import { keccak256 } from 'ethers/lib/utils';
 import { ApiPromise } from '@polkadot/api';
 import type { GenericExtrinsic, i32, u64 } from '@polkadot/types';
 import type { EventRecord } from '@polkadot/types/interfaces';

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import { FrameSystemEventRecord } from '@acala-network/types/interfaces/types-lookup';
+import { BigNumber } from '@ethersproject/bignumber';
 import { Extrinsic } from '@polkadot/types/interfaces';
 import { AnyFunction } from '@polkadot/types/types';
-import { BigNumber } from 'ethers';
 import { BlockTag, Eip1898BlockTag } from 'src/base-provider';
 import { CacheInspect } from './BlockCache';
 import { _Metadata } from './gqlTypes';


### PR DESCRIPTION
Theres a couple of reasons for this change:
- Greatly reduces the code size when bundling 
- Drops the imports of networking modules (http) so that it can be run in the SubQuery sandbox.