### PR TITLE
update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Some tools and SDKs related to Acala EVM.
 
 Packages:
 - [bodhi](./bodhi)
+- [eth-providers](./eth-providers)
 - [eth-rpc-adapter](./eth-rpc-adapter)
 - [evm-subql](./evm-subql)
 - [examples](./examples)
@@ -84,10 +85,10 @@ docker logs -f <container_id>           # logs for specific container
   - build locally: `docker build . -t evm-subql-local -f evm-subql/Dockerfile`
   - [public docker images](https://hub.docker.com/r/acala/evm-subql/tags)
 
-## Documentation
+## More References
 - This project is managed by [Rushstack](https://github.com/microsoft/rushstack).
-- Most of JsonRpc methods provided by [eth-rpc-adapter](./eth-rpc-adapter/) are compatible with [standard ETH JsonRpcs](https://ethereum.org/en/developers/docs/apis/json-rpc/), for more details please checkout [available RPCs](./eth-rpc-adapter/README.md#available-rpcs).
-- Most of the Apis of [eth-providers](./eth-providers/) is compatible with [ethers.js](https://docs.ethers.io/v5/single-page/) providers. (TODO: add more details)
+- Most of JSON-RPC methods provided by [eth-rpc-adapter](./eth-rpc-adapter/) are compatible with standard [ETH JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/), for more details please checkout [available RPCs](./eth-rpc-adapter/README.md#available-rpcs).
+- Most of the APIs of [eth-providers](./eth-providers/) is compatible with [ethers.js](https://docs.ethers.io/v5/single-page/) providers.
 
 ## Release Workflow
 ### manual

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# @acala-network/bodhi.js
-Some tools and SDKs related to Acala EVM.  
+# Acala EVM+ SDKs
+These are some tools and SDKs related to Acala EVM+. It also contains some examples about how to interact with EVM+ with these tools.
 
 Packages:
-- [bodhi](./bodhi)
+- [bodhi.js](./bodhi)
 - [eth-providers](./eth-providers)
 - [eth-rpc-adapter](./eth-rpc-adapter)
 - [evm-subql](./evm-subql)

--- a/eth-providers/README.md
+++ b/eth-providers/README.md
@@ -2,12 +2,21 @@
 This package includes two providers:
 
 **EvmRpcProvider**
-It is an abstract connection to EVM+, it's APIs is mostly compatible with ethers.js [JsonRpcProvider](https://docs.ethers.io/v5/single-page/#/v5/api/providers/jsonrpc-provider/-%23-JsonRpcProvider). Note that it is usually used internally by [eth-rpc-adapter](../eth-rpc-adapter) to provide standard [ETH JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/), so in most cases we don't use it directly.
+It is an abstract connection to EVM+, the APIs is mostly compatible with ethers.js [JsonRpcProvider](https://docs.ethers.io/v5/single-page/#/v5/api/providers/jsonrpc-provider/-%23-JsonRpcProvider). It is used internally by [eth-rpc-adapter](../eth-rpc-adapter) to provide standard [ETH JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/), which is the preferred way to interact with EVM+. 
 
 **SignerProvider**
 It is similar to `EvmRpcProvider`, but mostly used by [bodhi signer](../bodhi/).
 
 ## Getting Started
+As mentioned above, the [ETH JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/) is more common way to interact with EVM+. So in most cases we don't use the provider directly, but if you do need to, below are some examples.
+
+### install
+```
+yarn add @acala-network/eth-providers
+### or 
+npm install @acala-network/eth-providers
+```
+
 ### create a provider instance 
 ```ts
 import { EvmRpcProvider } from "@acala-network/eth-providers";

--- a/eth-providers/README.md
+++ b/eth-providers/README.md
@@ -1,19 +1,44 @@
 # @acala-network/eth-providers
+This package includes two providers:
 
-Providers that contain some reusable functionalities for bodhi and eth-rpc-adapter.
+**EvmRpcProvider**
+It is an abstract connection to EVM+, it's APIs is mostly compatible with ethers.js [JsonRpcProvider](https://docs.ethers.io/v5/single-page/#/v5/api/providers/jsonrpc-provider/-%23-JsonRpcProvider). Note that it is usually used internally by [eth-rpc-adapter](../eth-rpc-adapter) to provide standard [ETH JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/), so in most cases we don't use it directly.
 
-## Run
-- install deps
-```
-rush udpate
+**SignerProvider**
+It is similar to `EvmRpcProvider`, but mostly used by [bodhi signer](../bodhi/).
+
+## Getting Started
+### create a provider instance 
+```ts
+import { EvmRpcProvider } from "@acala-network/eth-providers";
+
+const KARURA_NODE_ENDPOINT = 'wss://karura-rpc-0.aca-api.network';
+const KARURA_SUBQL_URL = 'https://subql-query-karura.aca-api.network';
+
+const provider = new EvmRpcProvider(
+  KARURA_NODE_ENDPOINT,
+  { subqlUrl: KARURA_SUBQL_URL },   // optional
+);
+await provider.isReady();
 ```
 
-- build typescript types (if there is any graphql schema change)
-```
-yarn gql:typegen
+### use the provider
+some method doesn't rely on subquery, so `subqlUrl` is **optional**
+```ts
+const chainId = await provider.chainId();
+const curBlock = await provider.getBlockNumber();
+const balance = await provider.getBalance('0x1c3D657F0518A094BF351852bad4285EFc0D5Ce9');
+const blockData = await provider.getBlockData('latest', false);
 ```
 
-- build
+if we need to get historical logs and receipt, `subqlUrl` is **required**
+```ts
+const fullBlockData = await provider.getBlockData('latest', true);
+const recepit = await provider.getTXReceiptByHash('0xa82791bb02323ead8caa02adadd9fa2fde015d81bc170e5fd484306d060d016e');
+const logs = await provider.getLogs({
+  blockHash: '0xd24265fa4cc387810ba2378c816142f65cb6a3c98bc8a6e206e294d8b50f6a21',
+});
+
+await provider.disconnect();
 ```
-rush build -t .
-```
+for a full list of available methods, please checkout the [source code](./src/base-provider.ts)

--- a/evm-subql/README.md
+++ b/evm-subql/README.md
@@ -6,13 +6,13 @@ Subquery services that index and query Acala EVM+ transactions and logs.
 
 ### Prepare
 
-- Install the required dependencies
+- install dependencies
 
 ```
 yarn
 ```
 
-- Generate the required types from the GraphQL schema and build code
+- generate the required types from the GraphQL schema, and build code
 
 ```shell
 yarn build
@@ -166,8 +166,15 @@ query {
 
 Previous examples are examples of the **local development setup**, which uses the [example configuration](./project.yaml) that is tailored to local development node. 
 
-For production we need a slightly different configuration and usually need to start each of the `{ node, postgres, indexer, query }` seperately with Docker or k8s, instead of running them all in one Docker container.
+For production deployment, there are a couple differences: 
 
+#### services
+In local setup we can run all of the services all together with one single [docker compose](./docker-compose.yml). However, in prod we  usually need to start each of the `{ node, postgres, indexer, query }` seperately with Docker or k8s.
+
+#### image
+Notice that in the local example, we use `onfinality/subql-node:v1.9.1` as indexer, with **local mounted project path**. For prod we should use [acala/evm-subql](https://hub.docker.com/r/acala/evm-subql/tags) instead, which already has all the required files encapsulated, so we don't need to mount local files anymore.
+
+#### config
 One of the tricks is that we don't have to start indexing from block 0, since Acala and Karura didn't enable EVM+ until a certain block. In particular we can use these two configs for production (change the `endpoint` value to your custom one if needed):
 
 - [Acala production](./project-acala-840000.yaml)


### PR DESCRIPTION
- updated docs for `eth-rpc-adapter` and `evm-subql`
- added some examples for using `eth-providers`
- also changed the project name to `Acala EVM+ SDKs` to distinguish it from the `bodhi.js` pacakge