### PR TITLE
subql check genesishash match

### DIFF
--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -495,7 +495,7 @@ export abstract class BaseProvider extends AbstractProvider {
 
   chainId = async (): Promise<number> => {
     await this.api.isReadyOrError;
-    return (this.api.consts.evmAccounts.chainId as any).toNumber();
+    return this.api.consts.evmAccounts.chainId.toNumber();
   };
 
   getBlockNumber = async (): Promise<number> => {
@@ -720,8 +720,8 @@ export abstract class BaseProvider extends AbstractProvider {
     };
 
     const data = resolved.blockHash
-      ? await (this.api.rpc as any).evm.call(callRequest, resolved.blockHash)
-      : await (this.api.rpc as any).evm.call(callRequest);
+      ? await this.api.rpc.evm.call(callRequest, resolved.blockHash)
+      : await this.api.rpc.evm.call(callRequest);
 
     return data.toHex();
   };

--- a/eth-providers/src/utils/subqlProvider.ts
+++ b/eth-providers/src/utils/subqlProvider.ts
@@ -11,12 +11,15 @@ export class SubqlProvider {
     this.url = url;
   }
 
-  checkGraphql = async (): Promise<void> => {
+  checkGraphql = async (): Promise<string> => {
+    let metaData;
     try {
-      await this.getIndexerMetadata();
+      metaData = await this.getIndexerMetadata();
     } catch (e) {
-      logger.throwError(`Check Graphql failed: ${e}`);
+      logger.throwError(`Check Graphql failed, you might be using an invalid subquery url! Error: ${e}`);
     }
+
+    return metaData?.genesisHash as string;
   };
 
   queryGraphql = (query: string): Promise<Query> =>

--- a/eth-rpc-adapter/src/index.ts
+++ b/eth-rpc-adapter/src/index.ts
@@ -34,7 +34,15 @@ export async function start(): Promise<void> {
 
   await provider.isReady();
   if (provider.subql) {
-    await provider.subql?.checkGraphql();
+    const genesisHash = await provider.subql?.checkGraphql();
+    if (genesisHash !== provider.genesisHash) {
+      throw new Error(
+        `subql genesis hash doesn\'t match! You might have connected to a wrong subql' ${JSON.stringify({
+          subqlGenesisHash: genesisHash,
+          providerGenesisHash: provider.genesisHash
+        })}`
+      );
+    }
   }
 
   console.log(`


### PR DESCRIPTION
## Change
check subql genesis hash with the provider to make sure we connect to a correct subql. Metadata doesn't have chainId so we use genesis hash

fix #588 

## Test
manually tested and will throw error when connecting to wrong subql