### PR TITLE
remove unsupported CI option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: build bodhi base # if use self-hosted machine can utilize cache
         run: docker build . -t bodhi-base -f docker/bodhi-base.Dockerfile
       - name: test
-        run: docker compose up --remove-orphans --abort-on-container-exit --exit-code-from=eth-providers-test --build -- eth-providers-test
+        run: docker compose up --abort-on-container-exit --exit-code-from=eth-providers-test --build -- eth-providers-test
       - name: clean up after tests finished
         run: docker compose down -v
       - name: check docker info after cleaning
@@ -62,7 +62,7 @@ jobs:
       - name: build bodhi base # if use self-hosted machine can utilize cache
         run: docker build . -t bodhi-base -f docker/bodhi-base.Dockerfile
       - name: test
-        run: docker compose up --remove-orphans --abort-on-container-exit --exit-code-from=eth-rpc-adapter-test --build -- eth-rpc-adapter-test
+        run: docker compose up --abort-on-container-exit --exit-code-from=eth-rpc-adapter-test --build -- eth-rpc-adapter-test
       - name: clean up after tests finished
         run: docker compose down -v
       - name: check docker info after cleaning
@@ -90,7 +90,7 @@ jobs:
       - name: build bodhi base # if use self-hosted machine can utilize cache
         run: docker build . -t bodhi-base -f docker/bodhi-base.Dockerfile
       - name: test
-        run: docker compose up --remove-orphans --abort-on-container-exit --exit-code-from=waffle-examples-test --build -- waffle-examples-test
+        run: docker compose up --abort-on-container-exit --exit-code-from=waffle-examples-test --build -- waffle-examples-test
       - name: clean up after tests finished
         run: docker compose down -v
       - name: check docker info after cleaning
@@ -114,7 +114,7 @@ jobs:
   #  - name: build bodhi base # if use self-hosted machine can utilize cache
   #    run: docker build . -t bodhi-base -f docker/bodhi-base.Dockerfile#
   #  - name: test
-  #       run: docker compose up --remove-orphans --abort-on-container-exit --exit-code-from=waffle-tutorials-test --build -- waffle-tutorials-test
+  #       run: docker compose up --abort-on-container-exit --exit-code-from=waffle-tutorials-test --build -- waffle-tutorials-test
   #     - name: dump docker logs on failure
   #       if: failure()
   #       uses: jwalton/gh-docker-logs@v1
@@ -132,7 +132,7 @@ jobs:
       - name: build bodhi base # if use self-hosted machine can utilize cache
         run: docker build . -t bodhi-base -f docker/bodhi-base.Dockerfile
       - name: test
-        run: docker compose up --remove-orphans --abort-on-container-exit --exit-code-from=hardhat-tutorials-test --build -- hardhat-tutorials-test
+        run: docker compose up --abort-on-container-exit --exit-code-from=hardhat-tutorials-test --build -- hardhat-tutorials-test
       - name: dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v1
@@ -150,7 +150,7 @@ jobs:
       - name: build bodhi base # if use self-hosted machine can utilize cache
         run: docker build . -t bodhi-base -f docker/bodhi-base.Dockerfile
       - name: test
-        run: docker compose up --remove-orphans --abort-on-container-exit --exit-code-from=truffle-tutorials-test --build -- truffle-tutorials-test
+        run: docker compose up --abort-on-container-exit --exit-code-from=truffle-tutorials-test --build -- truffle-tutorials-test
       - name: dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v1


### PR DESCRIPTION
https://github.com/AcalaNetwork/bodhi.js/actions/runs/3531323249/jobs/5937981463

`--remove-orphans` option is not supported anymore, and it's not necessary, so removes it