### PR TITLE
replace `rpc.evm.call` with `state_call`

### DIFF
--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -40,6 +40,8 @@ const polkadotDeps = {
 
 const fixedDeps = {
   ...polkadotDeps,
+  "bn.js": "5.2.0",
+  "@types/bn.js": "5.1.0",
 } 
 
 // const projects = [

--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -40,9 +40,6 @@ const polkadotDeps = {
 
 const fixedDeps = {
   ...polkadotDeps,
-  // ...ethersDeps,
-  "bn.js": "4.12.0",
-  "@types/bn.js": "5.1.0",
 } 
 
 // const projects = [

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
 
   ../../eth-providers:
     specifiers:
-      '@acala-network/api': ~4.1.8-2.2
+      '@acala-network/api': ~4.1.8-2.3
       '@acala-network/contracts': ~4.3.4
       '@acala-network/eth-transactions': workspace:*
       '@acala-network/types': ~4.1.1
@@ -108,7 +108,7 @@ importers:
       typescript: ~4.6.3
       vitest: ~0.20.2
     dependencies:
-      '@acala-network/api': 4.1.8-2.2_@polkadot+types@9.9.1
+      '@acala-network/api': 4.1.8-2.3_@polkadot+types@9.9.1
       '@acala-network/contracts': 4.3.4
       '@acala-network/eth-transactions': link:../eth-transactions
       '@acala-network/types': 4.1.5_@polkadot+api@9.9.1
@@ -1191,8 +1191,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@acala-network/api/4.1.8-2.2_@polkadot+types@9.9.1:
-    resolution: {integrity: sha512-Pocbx1GkIczPPxwI3C5NNyvA2sz/LImMre8FX2SYN+15uYlag34hEK13Jqa/H/8VMrDVFUA1GDIEAVCHNuV8Rg==}
+  /@acala-network/api/4.1.8-2.3_@polkadot+types@9.9.1:
+    resolution: {integrity: sha512-moQGkL5sfeb1ZOduvdYgAeb99qWbRXW7MrW7PHS45UtExqdu7pv3JFtOJAsPQ6RT2dPYEtt0YxH0TAQixZlFUg==}
     peerDependencies:
       '@polkadot/types': '>=9'
     dependencies:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
       '@rushstack/eslint-config': ~2.5.4
       '@rushstack/heft': ~0.44.13
       '@sinonjs/fake-timers': ~9.1.1
-      '@types/bn.js': 5.1.0
+      '@types/bn.js': ~5.1.0
       '@types/chai': ~4.2.22
       '@types/chai-as-promised': ~7.1.4
       '@types/lru-cache': ~7.6.1
@@ -132,7 +132,6 @@ importers:
       '@polkadot/types': 9.9.1
       '@polkadot/util': 10.1.13
       '@polkadot/util-crypto': 10.1.13
-      '@types/bn.js': 5.1.0
       bn.js: 5.2.0
       ethers: 5.7.2
       graphql: 16.0.1
@@ -142,6 +141,7 @@ importers:
       '@rushstack/eslint-config': 2.5.4_eslint@7.32.0+typescript@4.6.3
       '@rushstack/heft': 0.44.13
       '@sinonjs/fake-timers': 9.1.1
+      '@types/bn.js': 5.1.0
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/lru-cache': 7.6.1

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
       '@polkadot/util-crypto': ^10.1.13
       '@rushstack/eslint-config': ~2.5.4
       '@rushstack/heft': ~0.44.13
-      '@types/bn.js': ~5.1.0
+      '@types/bn.js': 5.1.0
       '@types/chai': ~4.2.22
-      bn.js: ~5.2.0
+      bn.js: 5.2.0
       chai: ~4.3.4
       eslint: ~7.32.0
       ethers: ~5.7.0
@@ -48,7 +48,7 @@ importers:
       '@polkadot/util': 10.1.13
       '@polkadot/util-crypto': 10.1.13
       '@types/bn.js': 5.1.0
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       ethers: 5.7.2
     devDependencies:
       '@rushstack/eslint-config': 2.5.4_eslint@7.32.0+typescript@4.6.3
@@ -88,12 +88,12 @@ importers:
       '@rushstack/eslint-config': ~2.5.4
       '@rushstack/heft': ~0.44.13
       '@sinonjs/fake-timers': ~9.1.1
-      '@types/bn.js': ~5.1.0
+      '@types/bn.js': 5.1.0
       '@types/chai': ~4.2.22
       '@types/chai-as-promised': ~7.1.4
       '@types/lru-cache': ~7.6.1
       '@types/sinonjs__fake-timers': ~8.1.2
-      bn.js: ~5.2.0
+      bn.js: 5.2.0
       chai: ~4.3.4
       chai-as-promised: ~7.1.1
       chai-subset: ~1.6.0
@@ -132,7 +132,8 @@ importers:
       '@polkadot/types': 9.9.1
       '@polkadot/util': 10.1.13
       '@polkadot/util-crypto': 10.1.13
-      bn.js: 5.2.1
+      '@types/bn.js': 5.1.0
+      bn.js: 5.2.0
       ethers: 5.7.2
       graphql: 16.0.1
       graphql-request: 3.6.1_graphql@16.0.1
@@ -141,7 +142,6 @@ importers:
       '@rushstack/eslint-config': 2.5.4_eslint@7.32.0+typescript@4.6.3
       '@rushstack/heft': 0.44.13
       '@sinonjs/fake-timers': 9.1.1
-      '@types/bn.js': 5.1.0
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/lru-cache': 7.6.1
@@ -1229,7 +1229,7 @@ packages:
       '@polkadot/util': 10.1.13
       '@polkadot/util-crypto': 10.1.13
       '@types/bn.js': 5.1.0
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       ethers: 5.5.4
     transitivePeerDependencies:
       - bufferutil
@@ -2133,14 +2133,14 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
-      bn.js: 4.12.0
+      bn.js: 5.2.0
 
   /@ethersproject/bignumber/5.6.0:
     resolution: {integrity: sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==}
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
-      bn.js: 4.12.0
+      bn.js: 5.2.0
     dev: true
 
   /@ethersproject/bignumber/5.7.0:
@@ -2148,7 +2148,7 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
-      bn.js: 5.2.1
+      bn.js: 5.2.0
 
   /@ethersproject/bytes/5.5.0:
     resolution: {integrity: sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==}
@@ -2588,7 +2588,7 @@ packages:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       elliptic: 6.5.4
       hash.js: 1.1.7
 
@@ -2598,7 +2598,7 @@ packages:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       elliptic: 6.5.4
       hash.js: 1.1.7
 
@@ -2608,7 +2608,7 @@ packages:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       elliptic: 6.5.4
       hash.js: 1.1.7
 
@@ -3244,7 +3244,7 @@ packages:
   /@openzeppelin/upgrades-core/1.14.2:
     resolution: {integrity: sha512-JkrMcsB0v6vwX+fObY+y51L3tD3BcLjNpPnKkgtsEOC1Umwt6WzvI8Gq2brmNOzFLNQqeX2xySiJTGvypqUQow==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       cbor: 8.1.0
       chalk: 4.1.2
       compare-versions: 4.1.3
@@ -3582,8 +3582,8 @@ packages:
       '@polkadot/x-global': 10.1.13
       '@polkadot/x-textdecoder': 10.1.13
       '@polkadot/x-textencoder': 10.1.13
-      '@types/bn.js': 5.1.1
-      bn.js: 5.2.1
+      '@types/bn.js': 5.1.0
+      bn.js: 5.2.0
 
   /@polkadot/wasm-bridge/6.3.1_6e7e7bddc44fe27b4e07a73512098112:
     resolution: {integrity: sha512-1TYkHsb9AEFhU9uZj3biEnN2yKQNzdrwSjiTvfCYnt97pnEkKsZI6cku+YPZQv5w/x9CQa5Yua9e2DVVZSivGA==}
@@ -4422,7 +4422,7 @@ packages:
       '@truffle/abi-utils': 0.2.5
       '@truffle/compile-common': 0.7.23
       big.js: 5.2.2
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       cbor: 5.2.0
       debug: 4.3.3
       lodash.clonedeep: 4.5.0
@@ -4507,7 +4507,7 @@ packages:
       '@truffle/abi-utils': 0.2.5
       '@truffle/codec': 0.11.21
       '@truffle/source-map-utils': 1.3.65
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       debug: 4.3.3
       json-pointer: 0.6.1
       json-stable-stringify: 1.0.1
@@ -4559,7 +4559,7 @@ packages:
   /@truffle/interface-adapter/0.5.8:
     resolution: {integrity: sha512-vvy3xpq36oLgjjy8KE9l2Jabg3WcGPOt18tIyMfTQX9MFnbHoQA2Ne2i8xsd4p6KfxIqSjAB53Q9/nScAqY0UQ==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       ethers: 4.0.49
       web3: 1.5.3
     dev: false
@@ -4767,18 +4767,8 @@ packages:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
     dev: true
 
-  /@types/bn.js/4.11.6:
-    resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
-    dependencies:
-      '@types/node': 16.10.9
-
   /@types/bn.js/5.1.0:
     resolution: {integrity: sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==}
-    dependencies:
-      '@types/node': 16.10.9
-
-  /@types/bn.js/5.1.1:
-    resolution: {integrity: sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==}
     dependencies:
       '@types/node': 16.10.9
 
@@ -5855,7 +5845,7 @@ packages:
   /asn1.js/5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
@@ -6609,7 +6599,7 @@ packages:
     dependencies:
       bech32: 2.0.0
       bip-schnorr: 0.6.4
-      bn.js: 4.11.8
+      bn.js: 5.2.0
       bs58: 4.0.1
       buffer-compare: 1.1.1
       elliptic: 6.5.4
@@ -6648,19 +6638,8 @@ packages:
   /bluebird/3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  /bn.js/4.11.6:
-    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
-
-  /bn.js/4.11.8:
-    resolution: {integrity: sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==}
-    dev: false
-    optional: true
-
-  /bn.js/4.12.0:
-    resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
-
-  /bn.js/5.2.1:
-    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
+  /bn.js/5.2.0:
+    resolution: {integrity: sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==}
 
   /body-parser/1.19.1:
     resolution: {integrity: sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==}
@@ -6791,13 +6770,13 @@ packages:
   /browserify-rsa/4.1.0:
     resolution: {integrity: sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       randombytes: 2.1.0
 
   /browserify-sign/4.2.1:
     resolution: {integrity: sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       browserify-rsa: 4.1.0
       create-hash: 1.2.0
       create-hmac: 1.1.7
@@ -7622,7 +7601,7 @@ packages:
   /create-ecdh/4.0.4:
     resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       elliptic: 6.5.4
 
   /create-hash/1.2.0:
@@ -8099,7 +8078,7 @@ packages:
   /diffie-hellman/5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       miller-rabin: 4.0.1
       randombytes: 2.1.0
 
@@ -8276,7 +8255,7 @@ packages:
   /elliptic/6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       brorand: 1.1.0
       hash.js: 1.1.7
       hmac-drbg: 1.0.1
@@ -8952,7 +8931,7 @@ packages:
   /eth-lib/0.1.29:
     resolution: {integrity: sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       elliptic: 6.5.4
       nano-json-stream-parser: 0.1.2
       servify: 0.1.12
@@ -8962,7 +8941,7 @@ packages:
   /eth-lib/0.2.8:
     resolution: {integrity: sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       elliptic: 6.5.4
       xhr-request-promise: 0.1.3
 
@@ -9134,14 +9113,14 @@ packages:
   /ethereumjs-abi/0.6.5:
     resolution: {integrity: sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       ethereumjs-util: 4.5.1
     dev: true
 
   /ethereumjs-abi/0.6.8:
     resolution: {integrity: sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       ethereumjs-util: 6.2.1
 
   /ethereumjs-account/2.0.5:
@@ -9228,7 +9207,7 @@ packages:
   /ethereumjs-util/4.5.1:
     resolution: {integrity: sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       create-hash: 1.2.0
       elliptic: 6.5.4
       ethereum-cryptography: 0.1.3
@@ -9238,7 +9217,7 @@ packages:
   /ethereumjs-util/5.2.1:
     resolution: {integrity: sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       create-hash: 1.2.0
       elliptic: 6.5.4
       ethereum-cryptography: 0.1.3
@@ -9249,8 +9228,8 @@ packages:
   /ethereumjs-util/6.2.1:
     resolution: {integrity: sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==}
     dependencies:
-      '@types/bn.js': 4.11.6
-      bn.js: 4.12.0
+      '@types/bn.js': 5.1.0
+      bn.js: 5.2.0
       create-hash: 1.2.0
       elliptic: 6.5.4
       ethereum-cryptography: 0.1.3
@@ -9262,7 +9241,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@types/bn.js': 5.1.0
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       create-hash: 1.2.0
       ethereum-cryptography: 0.1.3
       rlp: 2.2.7
@@ -9337,7 +9316,7 @@ packages:
     resolution: {integrity: sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==}
     dependencies:
       aes-js: 3.0.0
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       elliptic: 6.5.4
       hash.js: 1.1.3
       js-sha3: 0.5.7
@@ -9465,7 +9444,7 @@ packages:
     resolution: {integrity: sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 4.11.6
+      bn.js: 5.2.0
       number-to-bn: 1.7.0
 
   /ethjs-util/0.1.6:
@@ -11997,7 +11976,7 @@ packages:
   /leb128/0.0.5:
     resolution: {integrity: sha512-elbNtfmu3GndZbesVF6+iQAfVjOXW9bM/aax9WwMlABZW+oK9sbAZEXoewaPHmL34sxa8kVwWsru8cNE/yn2gg==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       buffer-pipe: 0.0.3
     dev: false
     optional: true
@@ -12812,7 +12791,7 @@ packages:
     resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
     hasBin: true
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       brorand: 1.1.0
 
   /mime-db/1.51.0:
@@ -13625,7 +13604,7 @@ packages:
     resolution: {integrity: sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 4.11.6
+      bn.js: 5.2.0
       strip-hex-prefix: 1.0.0
 
   /nwmatcher/1.4.4:
@@ -14814,7 +14793,7 @@ packages:
   /public-encrypt/4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       browserify-rsa: 4.1.0
       create-hash: 1.2.0
       parse-asn1: 5.1.6
@@ -15455,7 +15434,7 @@ packages:
     resolution: {integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==}
     hasBin: true
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.0
 
   /rn-host-detect/1.2.0:
     resolution: {integrity: sha512-btNg5kzHcjZZ7t7mvvV/4wNJ9e3MPgrWivkRgWURzXL0JJ0pwWlU4zrbmdlz3HHzHOxhBhHB4D+/dbMFfu4/4A==}
@@ -16565,7 +16544,7 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       create-hmac: 1.1.7
       elliptic: 6.5.4
       nan: 2.15.0
@@ -17626,7 +17605,7 @@ packages:
     resolution: {integrity: sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 4.11.6
+      '@types/bn.js': 5.1.0
       '@types/node': 12.20.39
       bignumber.js: 9.0.2
       web3-core-helpers: 1.2.11
@@ -17640,7 +17619,7 @@ packages:
     resolution: {integrity: sha512-ACTbu8COCu+0eUNmd9pG7Q9EVsNkAg2w3Y7SqhDr+zjTgbSHZV01jXKlapm9z+G3AN/BziV3zGwudClJ4u4xXQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 4.11.6
+      '@types/bn.js': 5.1.0
       '@types/node': 12.20.39
       bignumber.js: 9.0.2
       web3-core-helpers: 1.5.3
@@ -17706,7 +17685,7 @@ packages:
     resolution: {integrity: sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 4.11.6
+      '@types/bn.js': 5.1.0
       underscore: 1.9.1
       web3-core: 1.2.11
       web3-core-helpers: 1.2.11
@@ -17722,7 +17701,7 @@ packages:
     resolution: {integrity: sha512-Gdlt1L6cdHe83k7SdV6xhqCytVtOZkjD0kY/15x441AuuJ4JLubCHuqu69k2Dr3tWifHYVys/vG8QE/W16syGg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 4.11.6
+      '@types/bn.js': 5.1.0
       web3-core: 1.5.3
       web3-core-helpers: 1.5.3
       web3-core-method: 1.5.3
@@ -17766,7 +17745,7 @@ packages:
     resolution: {integrity: sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       web3-utils: 1.2.11
     dev: true
     optional: true
@@ -17775,7 +17754,7 @@ packages:
     resolution: {integrity: sha512-vMzmGqolYZvRHwP9P4Nf6G8uYM5aTLlQu2a34vz78p0KlDC+eV1th3+90Qeaupa28EG7OO0IT1F0BejiIauOPw==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       web3-utils: 1.5.3
     dev: false
 
@@ -17967,7 +17946,7 @@ packages:
     resolution: {integrity: sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       eth-lib: 0.2.8
       ethereum-bloom-filters: 1.0.10
       ethjs-unit: 0.1.6
@@ -17982,7 +17961,7 @@ packages:
     resolution: {integrity: sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       eth-lib: 0.2.8
       ethereum-bloom-filters: 1.0.10
       ethjs-unit: 0.1.6
@@ -17995,7 +17974,7 @@ packages:
     resolution: {integrity: sha512-RidGKv5kOkcerI6jQqDFDoTllQQqV+rPhTzZHhmbqtFObbYpU93uc+yG1LHivRTQhA6llIx67iudc/vzisgO+w==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       ethereum-bloom-filters: 1.0.10
       ethereumjs-util: 7.1.3
       ethjs-unit: 0.1.6
@@ -18571,7 +18550,7 @@ packages:
       bip32: 2.0.6
       bip39: 3.0.4
       blakejs: 1.1.1
-      bn.js: 5.2.1
+      bn.js: 5.2.0
       ipld-dag-cbor: 0.17.1
       leb128: 0.0.5
       secp256k1: 4.0.2
@@ -18585,6 +18564,6 @@ packages:
     name: ethereumjs-abi
     version: 0.6.8
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.0
       ethereumjs-util: 6.2.1
     dev: true

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
       '@polkadot/util-crypto': ^10.1.13
       '@rushstack/eslint-config': ~2.5.4
       '@rushstack/heft': ~0.44.13
-      '@types/bn.js': 5.1.0
+      '@types/bn.js': ~5.1.0
       '@types/chai': ~4.2.22
-      bn.js: 4.12.0
+      bn.js: ~5.2.0
       chai: ~4.3.4
       eslint: ~7.32.0
       ethers: ~5.7.0
@@ -48,7 +48,7 @@ importers:
       '@polkadot/util': 10.1.13
       '@polkadot/util-crypto': 10.1.13
       '@types/bn.js': 5.1.0
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       ethers: 5.7.2
     devDependencies:
       '@rushstack/eslint-config': 2.5.4_eslint@7.32.0+typescript@4.6.3
@@ -93,6 +93,7 @@ importers:
       '@types/chai-as-promised': ~7.1.4
       '@types/lru-cache': ~7.6.1
       '@types/sinonjs__fake-timers': ~8.1.2
+      bn.js: ~5.2.0
       chai: ~4.3.4
       chai-as-promised: ~7.1.1
       chai-subset: ~1.6.0
@@ -131,6 +132,7 @@ importers:
       '@polkadot/types': 9.9.1
       '@polkadot/util': 10.1.13
       '@polkadot/util-crypto': 10.1.13
+      bn.js: 5.2.1
       ethers: 5.7.2
       graphql: 16.0.1
       graphql-request: 3.6.1_graphql@16.0.1
@@ -1227,7 +1229,7 @@ packages:
       '@polkadot/util': 10.1.13
       '@polkadot/util-crypto': 10.1.13
       '@types/bn.js': 5.1.0
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       ethers: 5.5.4
     transitivePeerDependencies:
       - bufferutil
@@ -2146,7 +2148,7 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
-      bn.js: 4.12.0
+      bn.js: 5.2.1
 
   /@ethersproject/bytes/5.5.0:
     resolution: {integrity: sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==}
@@ -2606,7 +2608,7 @@ packages:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       elliptic: 6.5.4
       hash.js: 1.1.7
 
@@ -3242,7 +3244,7 @@ packages:
   /@openzeppelin/upgrades-core/1.14.2:
     resolution: {integrity: sha512-JkrMcsB0v6vwX+fObY+y51L3tD3BcLjNpPnKkgtsEOC1Umwt6WzvI8Gq2brmNOzFLNQqeX2xySiJTGvypqUQow==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       cbor: 8.1.0
       chalk: 4.1.2
       compare-versions: 4.1.3
@@ -3580,8 +3582,8 @@ packages:
       '@polkadot/x-global': 10.1.13
       '@polkadot/x-textdecoder': 10.1.13
       '@polkadot/x-textencoder': 10.1.13
-      '@types/bn.js': 5.1.0
-      bn.js: 4.12.0
+      '@types/bn.js': 5.1.1
+      bn.js: 5.2.1
 
   /@polkadot/wasm-bridge/6.3.1_6e7e7bddc44fe27b4e07a73512098112:
     resolution: {integrity: sha512-1TYkHsb9AEFhU9uZj3biEnN2yKQNzdrwSjiTvfCYnt97pnEkKsZI6cku+YPZQv5w/x9CQa5Yua9e2DVVZSivGA==}
@@ -4420,7 +4422,7 @@ packages:
       '@truffle/abi-utils': 0.2.5
       '@truffle/compile-common': 0.7.23
       big.js: 5.2.2
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       cbor: 5.2.0
       debug: 4.3.3
       lodash.clonedeep: 4.5.0
@@ -4505,7 +4507,7 @@ packages:
       '@truffle/abi-utils': 0.2.5
       '@truffle/codec': 0.11.21
       '@truffle/source-map-utils': 1.3.65
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       debug: 4.3.3
       json-pointer: 0.6.1
       json-stable-stringify: 1.0.1
@@ -4557,7 +4559,7 @@ packages:
   /@truffle/interface-adapter/0.5.8:
     resolution: {integrity: sha512-vvy3xpq36oLgjjy8KE9l2Jabg3WcGPOt18tIyMfTQX9MFnbHoQA2Ne2i8xsd4p6KfxIqSjAB53Q9/nScAqY0UQ==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       ethers: 4.0.49
       web3: 1.5.3
     dev: false
@@ -4765,8 +4767,18 @@ packages:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
     dev: true
 
+  /@types/bn.js/4.11.6:
+    resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
+    dependencies:
+      '@types/node': 16.10.9
+
   /@types/bn.js/5.1.0:
     resolution: {integrity: sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==}
+    dependencies:
+      '@types/node': 16.10.9
+
+  /@types/bn.js/5.1.1:
+    resolution: {integrity: sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==}
     dependencies:
       '@types/node': 16.10.9
 
@@ -6597,7 +6609,7 @@ packages:
     dependencies:
       bech32: 2.0.0
       bip-schnorr: 0.6.4
-      bn.js: 4.12.0
+      bn.js: 4.11.8
       bs58: 4.0.1
       buffer-compare: 1.1.1
       elliptic: 6.5.4
@@ -6636,8 +6648,19 @@ packages:
   /bluebird/3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  /bn.js/4.11.6:
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
+
+  /bn.js/4.11.8:
+    resolution: {integrity: sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==}
+    dev: false
+    optional: true
+
   /bn.js/4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
+
+  /bn.js/5.2.1:
+    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
 
   /body-parser/1.19.1:
     resolution: {integrity: sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==}
@@ -6768,13 +6791,13 @@ packages:
   /browserify-rsa/4.1.0:
     resolution: {integrity: sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       randombytes: 2.1.0
 
   /browserify-sign/4.2.1:
     resolution: {integrity: sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       browserify-rsa: 4.1.0
       create-hash: 1.2.0
       create-hmac: 1.1.7
@@ -9226,7 +9249,7 @@ packages:
   /ethereumjs-util/6.2.1:
     resolution: {integrity: sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==}
     dependencies:
-      '@types/bn.js': 5.1.0
+      '@types/bn.js': 4.11.6
       bn.js: 4.12.0
       create-hash: 1.2.0
       elliptic: 6.5.4
@@ -9239,7 +9262,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@types/bn.js': 5.1.0
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       create-hash: 1.2.0
       ethereum-cryptography: 0.1.3
       rlp: 2.2.7
@@ -9442,7 +9465,7 @@ packages:
     resolution: {integrity: sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 4.11.6
       number-to-bn: 1.7.0
 
   /ethjs-util/0.1.6:
@@ -11974,7 +11997,7 @@ packages:
   /leb128/0.0.5:
     resolution: {integrity: sha512-elbNtfmu3GndZbesVF6+iQAfVjOXW9bM/aax9WwMlABZW+oK9sbAZEXoewaPHmL34sxa8kVwWsru8cNE/yn2gg==}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       buffer-pipe: 0.0.3
     dev: false
     optional: true
@@ -13602,7 +13625,7 @@ packages:
     resolution: {integrity: sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 4.11.6
       strip-hex-prefix: 1.0.0
 
   /nwmatcher/1.4.4:
@@ -15432,7 +15455,7 @@ packages:
     resolution: {integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==}
     hasBin: true
     dependencies:
-      bn.js: 4.12.0
+      bn.js: 5.2.1
 
   /rn-host-detect/1.2.0:
     resolution: {integrity: sha512-btNg5kzHcjZZ7t7mvvV/4wNJ9e3MPgrWivkRgWURzXL0JJ0pwWlU4zrbmdlz3HHzHOxhBhHB4D+/dbMFfu4/4A==}
@@ -17603,7 +17626,7 @@ packages:
     resolution: {integrity: sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 5.1.0
+      '@types/bn.js': 4.11.6
       '@types/node': 12.20.39
       bignumber.js: 9.0.2
       web3-core-helpers: 1.2.11
@@ -17617,7 +17640,7 @@ packages:
     resolution: {integrity: sha512-ACTbu8COCu+0eUNmd9pG7Q9EVsNkAg2w3Y7SqhDr+zjTgbSHZV01jXKlapm9z+G3AN/BziV3zGwudClJ4u4xXQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 5.1.0
+      '@types/bn.js': 4.11.6
       '@types/node': 12.20.39
       bignumber.js: 9.0.2
       web3-core-helpers: 1.5.3
@@ -17683,7 +17706,7 @@ packages:
     resolution: {integrity: sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 5.1.0
+      '@types/bn.js': 4.11.6
       underscore: 1.9.1
       web3-core: 1.2.11
       web3-core-helpers: 1.2.11
@@ -17699,7 +17722,7 @@ packages:
     resolution: {integrity: sha512-Gdlt1L6cdHe83k7SdV6xhqCytVtOZkjD0kY/15x441AuuJ4JLubCHuqu69k2Dr3tWifHYVys/vG8QE/W16syGg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 5.1.0
+      '@types/bn.js': 4.11.6
       web3-core: 1.5.3
       web3-core-helpers: 1.5.3
       web3-core-method: 1.5.3
@@ -18548,7 +18571,7 @@ packages:
       bip32: 2.0.6
       bip39: 3.0.4
       blakejs: 1.1.1
-      bn.js: 4.12.0
+      bn.js: 5.2.1
       ipld-dag-cbor: 0.17.1
       leb128: 0.0.5
       secp256k1: 4.0.2

--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -15,8 +15,8 @@
     "gql:typegen": "graphql-codegen --config codegen.yml"
   },
   "dependencies": {
-    "@acala-network/api": "~4.1.8-2.2",
-    "@acala-network/types": "~4.1.8-2.2",
+    "@acala-network/api": "~4.1.8-2.3",
+    "@acala-network/types": "~4.1.8-2.3",
     "@acala-network/contracts": "~4.3.4",
     "@acala-network/eth-transactions": "workspace:*",
     "@ethersproject/abstract-provider": "~5.7.0",

--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -41,6 +41,7 @@
     "ethers": "~5.7.0",
     "graphql": "~16.0.1",
     "graphql-request": "~3.6.1",
+    "bn.js": "~5.2.0",
     "lru-cache": "~7.8.2"
   },
   "devDependencies": {

--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -42,7 +42,6 @@
     "graphql": "~16.0.1",
     "graphql-request": "~3.6.1",
     "bn.js": "~5.2.0",
-    "@types/bn.js": "~5.1.0",
     "lru-cache": "~7.8.2"
   },
   "devDependencies": {

--- a/eth-providers/package.json
+++ b/eth-providers/package.json
@@ -42,6 +42,7 @@
     "graphql": "~16.0.1",
     "graphql-request": "~3.6.1",
     "bn.js": "~5.2.0",
+    "@types/bn.js": "~5.1.0",
     "lru-cache": "~7.8.2"
   },
   "devDependencies": {

--- a/eth-providers/src/__tests__/e2e/tx.test.ts
+++ b/eth-providers/src/__tests__/e2e/tx.test.ts
@@ -142,7 +142,7 @@ describe('transaction tests', () => {
           gasLimit: txGasLimit,
           gasPrice: txGasPrice
         })
-      ).to.be.rejectedWith('OutOfFund');
+      ).to.be.rejectedWith('outOfFund');
     });
 
     it('ExistentialDeposit', async () => {

--- a/eth-providers/src/__tests__/utils.test.ts
+++ b/eth-providers/src/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import chai from 'chai';
 import chaiSubset from 'chai-subset';
 import { describe, it } from 'vitest';
 import {
+  decodeRevertMsg,
   EthCallTimingResult,
   getHealthResult,
   hexlifyRpcResult,
@@ -393,5 +394,14 @@ describe('parseBlockTag', () => {
     expect(await parseBlockTag({ blockNumber: blockNumberHex })).to.equal(blockNumberHex);
     expect(await parseBlockTag({ blockNumber })).to.equal(blockNumber);
     expect(await parseBlockTag({ blockHash })).to.equal(blockHash);
+  });
+});
+
+describe('decodeRevertMsg', () => {
+  it('correctly decode', () => {
+    const hexData =
+      '0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013696e76616c69642063757272656e6379206964';
+
+    expect(decodeRevertMsg(hexData)).to.equal('invalid currency id');
   });
 });

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -731,8 +731,9 @@ export abstract class BaseProvider extends AbstractProvider {
       blockHash: this._getBlockHash(blockTag)
     });
 
-    const transaction =
-      txRequest.gasLimit && txRequest.gasPrice ? txRequest : { ...txRequest, ...(await this._getEthGas()) };
+    const transaction = txRequest.gasLimit && txRequest.gasPrice
+       ? txRequest
+       : { ...txRequest, ...(await this._getEthGas()) };
 
     const { storageLimit, gasLimit } = this._getSubstrateGasParams(transaction);
 
@@ -1123,18 +1124,10 @@ export abstract class BaseProvider extends AbstractProvider {
 
     if (ethTx.type === 96) {
       // EIP-712 transaction
-      if (!ethTx.gasLimit) {
-        return logger.throwError('expect gasLimit');
-      }
-      if (!ethTx.storageLimit) {
-        return logger.throwError('expect storageLimit');
-      }
-      if (!ethTx.validUntil) {
-        return logger.throwError('expect validUntil');
-      }
-      if (!ethTx.tip) {
-        return logger.throwError('expect priorityFee (tip)');
-      }
+      if (!ethTx.gasLimit) return logger.throwError('expect gasLimit');
+      if (!ethTx.storageLimit) return logger.throwError('expect storageLimit');
+      if (!ethTx.validUntil) return logger.throwError('expect validUntil');
+      if (!ethTx.tip) return logger.throwError('expect priorityFee (tip)');
 
       gasLimit = ethTx.gasLimit.toBigInt();
       storageLimit = BigInt(ethTx.storageLimit.toString());

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -698,32 +698,66 @@ export abstract class BaseProvider extends AbstractProvider {
   };
 
   call = async (
-    transaction: Deferrable<TransactionRequest>,
+    _transaction: Deferrable<TransactionRequest>,
     _blockTag?: BlockTag | Promise<BlockTag> | Eip1898BlockTag
   ): Promise<string> => {
     await this.getNetwork();
     const blockTag = await this._ensureSafeModeBlockTagFinalization(await parseBlockTag(_blockTag));
 
-    const resolved = await resolveProperties({
-      transaction: this._getTransactionRequest(transaction),
+    let { transaction, blockHash } = await resolveProperties({
+      transaction: this._getTransactionRequest(_transaction),
       blockHash: this._getBlockHash(blockTag)
     });
 
+    if (!(transaction.gasLimit && transaction.gasPrice)) {
+      const defaultGas = await this._getEthGas();
+      transaction = { ...transaction, ...defaultGas };
+    }
+    const { storageLimit, gasLimit } = this._getSubstrateGasParams({ ...transaction });
+
     const callRequest: CallRequest = {
-      from: resolved.transaction.from,
-      to: resolved.transaction.to,
-      gasLimit: resolved.transaction.gasLimit?.toBigInt(),
-      storageLimit: undefined,
-      value: resolved.transaction.value?.toBigInt(),
-      data: resolved.transaction.data,
-      accessList: resolved.transaction.accessList
+      from: transaction.from,
+      to: transaction.to,
+      gasLimit,
+      storageLimit,
+      value: transaction.value?.toBigInt(),
+      data: transaction.data,
+      accessList: transaction.accessList
     };
 
-    const data = resolved.blockHash
-      ? await this.api.rpc.evm.call(callRequest, resolved.blockHash)
-      : await this.api.rpc.evm.call(callRequest);
+    return blockHash ? this._ethCall(callRequest, blockHash) : this._ethCall(callRequest);
+  };
 
-    return data.toHex();
+  _ethCall = async (callRequest: CallRequest, at?: string): Promise<string> => {
+    const api = at ? await this.api.at(at) : this.api;
+
+    const { from, to, gasLimit, storageLimit, value, data, accessList } = callRequest;
+    const estimate = true;
+
+    const response = await api.call.evmRuntimeRPCApi.call(
+      from,
+      to,
+      data,
+      value,
+      gasLimit,
+      storageLimit,
+      accessList,
+      estimate
+    );
+
+    const res = response.toJSON() as any; // TODO: fix type
+    if (!res.ok) return logger.throwError(`eth call failed: ${res}`, Logger.errors.CALL_EXCEPTION, callRequest);
+
+    if (res.ok.exit_reason?.succeed) {
+      return res.ok.value;
+    } else {
+      const err = res.ok.exit_reason.error || res.ok.exit_reason.revert || res.ok.exit_reason.fatal || 'unknow error';
+      return logger.throwError(
+        `internal JSON-RPC error: ${JSON.stringify(err)}`,
+        Logger.errors.CALL_EXCEPTION,
+        callRequest
+      );
+    }
   };
 
   getStorageAt = async (
@@ -1040,7 +1074,7 @@ export abstract class BaseProvider extends AbstractProvider {
   };
 
   _getSubstrateGasParams = (
-    ethTx: AcalaEvmTX
+    ethTx: Partial<AcalaEvmTX>
   ): {
     gasLimit: bigint;
     storageLimit: bigint;
@@ -1055,30 +1089,29 @@ export abstract class BaseProvider extends AbstractProvider {
 
     if (ethTx.type === 96) {
       // EIP-712 transaction
-      const _storageLimit = ethTx.storageLimit?.toString();
-      const _validUntil = ethTx.validUntil?.toString();
-      const _tip = ethTx.tip?.toString();
-
-      if (!_storageLimit) {
+      if (!ethTx.gasLimit) {
+        return logger.throwError('expect gasLimit');
+      }
+      if (!ethTx.storageLimit) {
         return logger.throwError('expect storageLimit');
       }
-      if (!_validUntil) {
+      if (!ethTx.validUntil) {
         return logger.throwError('expect validUntil');
       }
-      if (!_tip) {
-        return logger.throwError('expect priorityFee');
+      if (!ethTx.tip) {
+        return logger.throwError('expect priorityFee (tip)');
       }
 
       gasLimit = ethTx.gasLimit.toBigInt();
-      storageLimit = BigInt(_storageLimit);
-      validUntil = BigInt(_validUntil);
-      tip = BigInt(_tip);
+      storageLimit = BigInt(ethTx.storageLimit.toString());
+      validUntil = BigInt(ethTx.validUntil.toString());
+      tip = BigInt(ethTx.tip.toString());
     } else if (ethTx.type === null || ethTx.type === undefined || ethTx.type === 0 || ethTx.type === 2) {
       // Legacy, EIP-155, and EIP-1559 transaction
       const { storageDepositPerByte, txFeePerGas } = this._getGasConsts();
 
       const _getErrInfo = (): any => ({
-        txGasLimit: ethTx.gasLimit.toBigInt(),
+        txGasLimit: ethTx.gasLimit?.toBigInt(),
         txGasPrice: ethTx.gasPrice?.toBigInt(),
         maxPriorityFeePerGas: ethTx.maxPriorityFeePerGas?.toBigInt(),
         maxFeePerGas: ethTx.maxFeePerGas?.toBigInt(),
@@ -1086,7 +1119,7 @@ export abstract class BaseProvider extends AbstractProvider {
         storageDepositPerByte
       });
 
-      const err_help_msg =
+      const errHelpMsg =
         'invalid ETH gasLimit/gasPrice combination provided. Please DO NOT change gasLimit/gasPrice in metamask when sending token, if you are deploying contract, DO NOT provide random gasLimit/gasPrice, please check out our doc for how to compute gas, easiest way is to call eth_getEthGas directly';
 
       try {
@@ -1102,15 +1135,15 @@ export abstract class BaseProvider extends AbstractProvider {
         storageLimit = params.storageLimit.toBigInt();
         tip = (ethTx.maxPriorityFeePerGas?.toBigInt() || 0n) * gasLimit;
       } catch {
-        logger.throwError(
-          `calculating substrate gas failed: ${err_help_msg}`,
+        return logger.throwError(
+          `calculating substrate gas failed: ${errHelpMsg}`,
           Logger.errors.INVALID_ARGUMENT,
           _getErrInfo()
         );
       }
 
       if (gasLimit < 0n || validUntil < 0n || storageLimit < 0n) {
-        logger.throwError(`bad substrate gas params caused by ${err_help_msg}`, Logger.errors.INVALID_ARGUMENT, {
+        return logger.throwError(`bad substrate gas params caused by ${errHelpMsg}`, Logger.errors.INVALID_ARGUMENT, {
           ..._getErrInfo(),
           gasLimit,
           validUntil,
@@ -1161,7 +1194,7 @@ export abstract class BaseProvider extends AbstractProvider {
       accessList: ethTx.accessList
     };
 
-    await this.api.rpc.evm.call(callRequest);
+    await this._ethCall(callRequest);
 
     const extrinsic = this.api.tx.evm.ethCall(
       ethTx.to ? { Call: ethTx.to } : { Create: null },

--- a/eth-providers/src/rpc-provider.ts
+++ b/eth-providers/src/rpc-provider.ts
@@ -1,13 +1,19 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { options } from '@acala-network/api';
 import { BaseProvider, BaseProviderOptions } from './base-provider';
+import { extraRuntimeTypes } from './utils';
 
 export class EvmRpcProvider extends BaseProvider {
   constructor(endpoint: string | string[], opts?: BaseProviderOptions) {
     super(opts);
 
     const provider = new WsProvider(endpoint);
-    const api = new ApiPromise(options({ provider }));
+    const api = new ApiPromise(
+      options({
+        provider,
+        types: extraRuntimeTypes
+      })
+    );
 
     this.setApi(api);
     this.startSubscription() as unknown as void;

--- a/eth-providers/src/signer-provider.ts
+++ b/eth-providers/src/signer-provider.ts
@@ -2,11 +2,17 @@ import { ApiPromise } from '@polkadot/api';
 import type { ApiOptions } from '@polkadot/api/types';
 import { options } from '@acala-network/api';
 import { BaseProvider } from './base-provider';
+import { extraRuntimeTypes } from './utils';
 
 export class SignerProvider extends BaseProvider {
   constructor(apiOptions: ApiOptions) {
     super();
-    const api = new ApiPromise(options(apiOptions));
+    const api = new ApiPromise(
+      options({
+        ...apiOptions,
+        types: extraRuntimeTypes
+      })
+    );
     this.setApi(api);
   }
 

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -279,3 +279,14 @@ export const parseBlockTag = async (_blockTag: BlockTagish | Eip1898BlockTag): P
 
   return blockTag.blockHash || blockTag.blockNumber;
 };
+
+// TODO: this can also bubble up to acala.js
+export const extraRuntimeTypes = {
+  CallInfo: {
+    exit_reason: 'EvmCoreErrorExitReason',
+    value: 'Vec<u8>',
+    used_gas: 'U256',
+    used_storage: 'i32',
+    logs: 'Vec<EthereumLog>'
+  }
+};

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -292,13 +292,16 @@ export const extraRuntimeTypes = {
   }
 };
 
+// https://github.com/AcalaNetwork/Acala/blob/067b65bc19ff525bdccae020ad2bd4bdf41f4300/modules/evm/rpc/src/lib.rs#L122
 export const decodeRevertMsg = (hexMsg: string) => {
   const data = hexToU8a(hexMsg);
   const msgStart = 68;
+  if (data.length <= msgStart) return '';
+
   const msgLength = BigNumber.from(data.slice(36, msgStart));
   const msgEnd = msgStart + msgLength.toNumber();
 
-  if (data.length <= msgStart || data.length < msgEnd) return '';
+  if (data.length < msgEnd) return '';
 
   const body = data.slice(msgStart, msgEnd);
 

--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -2,6 +2,7 @@ import { FrameSystemEventRecord } from '@acala-network/types/interfaces/types-lo
 import { BigNumber } from '@ethersproject/bignumber';
 import { Extrinsic } from '@polkadot/types/interfaces';
 import { AnyFunction } from '@polkadot/types/types';
+import { hexToU8a } from '@polkadot/util';
 import { BlockTagish, Eip1898BlockTag } from '../base-provider';
 import { CacheInspect } from './BlockCache';
 import { _Metadata } from './gqlTypes';
@@ -289,4 +290,17 @@ export const extraRuntimeTypes = {
     used_storage: 'i32',
     logs: 'Vec<EthereumLog>'
   }
+};
+
+export const decodeRevertMsg = (hexMsg: string) => {
+  const data = hexToU8a(hexMsg);
+  const msgStart = 68;
+  const msgLength = BigNumber.from(data.slice(36, msgStart));
+  const msgEnd = msgStart + msgLength.toNumber();
+
+  if (data.length <= msgStart || data.length < msgEnd) return '';
+
+  const body = data.slice(msgStart, msgEnd);
+
+  return new TextDecoder('utf-8').decode(body);
 };

--- a/eth-rpc-adapter/src/__tests__/e2e/errors.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/errors.test.ts
@@ -101,6 +101,6 @@ describe('errors', () => {
     const rawTx = await poorWallet.signTransaction(tx);
     const res = await eth_sendRawTransaction([rawTx]);
 
-    expect(res.data.message).to.contain('Invalid decimals');
+    expect(res.data.error.message).to.contain('Invalid decimals');
   });
 });

--- a/eth-rpc-adapter/src/__tests__/e2e/errors.test.ts
+++ b/eth-rpc-adapter/src/__tests__/e2e/errors.test.ts
@@ -101,14 +101,6 @@ describe('errors', () => {
     const rawTx = await poorWallet.signTransaction(tx);
     const res = await eth_sendRawTransaction([rawTx]);
 
-    expect(res.data).to.deep.equal({
-      id: 0,
-      jsonrpc: '2.0',
-      error: {
-        code: -32603,
-        message:
-          'internal JSON-RPC error [evm.InvalidDecimals: Invalid decimals]. More info: https://evmdocs.acala.network/reference/common-errors'
-      }
-    });
+    expect(res.data.message).to.contain('Invalid decimals');
   });
 });


### PR DESCRIPTION
## Change
use `state_call` to implement a eth call, similar to how the rust version did. Now the eth calls won't invoke any `api.rpc.evm.call` anymore.

## Test
- added some unit tests for the helper functions
- manually tested a couple simple `eth_call` and worked
- many of the existing e2e tests call `eth_call` directly or indirectly, which still pass, so I didn't add more tests for `eth_call` itself.