### PR TITLE
subql temp skip xcm

### DIFF
--- a/evm-subql/project-karura-2936170.yaml
+++ b/evm-subql/project-karura-2936170.yaml
@@ -1,0 +1,28 @@
+specVersion: 1.0.0
+name: '@acala-network/evm-subql'
+version: 1.0.0
+runner:
+  node:
+    name: '@subql/node'
+    version: 1.17.0
+  query:
+    name: '@subql/query'
+    version: 1.4.0
+description: 'subquery for Karura EVM+'
+repository: 'https://github.com/AcalaNetwork/bodhi.js/tree/master/evm-subql'
+schema:
+  file: ./schema.graphql
+network:
+  # Karura
+  chainId: '0xbaf5aabe40646d11f0ee8abbdc64f4a4b7674925cba08e4a05ff9ebed6e2126b'
+  endpoint: wss://karura-rpc-0.aca-api.network
+  chaintypes:
+    file: ./types.json
+dataSources:
+  - kind: substrate/Runtime
+    startBlock: 2936170
+    mapping:
+      file: ./dist/index.js
+      handlers:
+        - handler: handleBlock
+          kind: substrate/BlockHandler

--- a/evm-subql/src/mappings/mappingHandlers.ts
+++ b/evm-subql/src/mappings/mappingHandlers.ts
@@ -167,7 +167,8 @@ export async function handleBlock(block: SubstrateBlock): Promise<void> {
         return null;
       }
     })
-    .filter((x) => !!x);
+    .filter((x) => !!x)
+    .filter((x) => x.extrinsic.method.method.toString() !== 'setValidationData'); // temp skip erc20 xcm
 
   // TODO: reuse isOrphanEvmEvent
   const orphanEvmEvents = blockEvents.filter(


### PR DESCRIPTION
currently we can't deal with a new type of evm tx: [erc20 xcm](https://karura.subscan.io/block/2936174). This will cause subql throw error. Until we support this kind of tx, we can temporarily skip it.