### PR TITLE
added exit reason to receipt

### DIFF
--- a/eth-providers/src/__tests__/e2e/receipt-snapshots.ts
+++ b/eth-providers/src/__tests__/e2e/receipt-snapshots.ts
@@ -425,6 +425,7 @@ export const acala1555311b = {
   contractAddress: null,
   transactionIndex: '0x1',
   gasUsed: '0x237fd',
+  exitReason: '{\"revert\":\"Reverted\"}',
   logsBloom: DUMMY_LOGS_BLOOM,
   blockHash: '0xf9655bfef23bf7dad14a037aa39758daccfd8dc99a7ce69525f81548068a5946',
   transactionHash: '0x240a9ec2efdacae2a89486980874b23987b9801fd1ca7a424506629b71a53fa6',
@@ -449,6 +450,7 @@ export const acala1102030a = {
   blockNumber: '0x10d0ce',
   cumulativeGasUsed: '0x0',
   effectiveGasPrice: '0x513d6f23',
+  exitReason: '{\"error\":{\"other\":\"ReserveStorageFailed\"}}',
   status: '0x0',
   type: '0x0',
 };
@@ -466,6 +468,7 @@ export const acala1102030b = {
   blockNumber: '0x10d0ce',
   cumulativeGasUsed: '0x0',
   effectiveGasPrice: '0x2a1c0bcb',
+  exitReason: '{\"error\":{\"other\":\"ReserveStorageFailed\"}}',
   status: '0x0',
   type: '0x0',
 };

--- a/eth-providers/src/utils/transactionReceiptHelper.ts
+++ b/eth-providers/src/utils/transactionReceiptHelper.ts
@@ -40,6 +40,10 @@ export interface ExtrinsicMethodJSON {
   };
 }
 
+export interface FullReceipt extends TransactionReceipt {
+  exitReason?: string,
+};
+
 export const getPartialLog = (evmLog: EvmLog, logIndex: number): PartialLog => {
   return {
     removed: false,
@@ -349,12 +353,18 @@ const nToU8aLegacy = (...params: Parameters<typeof nToU8a>): ReturnType<typeof n
   return params[0] === 0 ? new Uint8Array() : nToU8a(...params);
 };
 
+const formatter = new Formatter();
+export const fullReceiptFormatter = {
+  ...formatter.formats.receipt,
+  exitReason: (x: any) => x,
+};
+
 export const getOrphanTxReceiptsFromEvents = (
   events: FrameSystemEventRecord[],
   blockHash: string,
   blockNumber: number,
   indexOffset: number
-): TransactionReceipt[] => {
+): FullReceipt[] => {
   const receipts = events
     .filter(isOrphanEvmEvent)
     .map(getPartialTransactionReceipt)
@@ -380,6 +390,5 @@ export const getOrphanTxReceiptsFromEvents = (
       };
     });
 
-  const formatter = new Formatter();
-  return receipts.map(formatter.receipt.bind(formatter));
+  return receipts.map(receipt => Formatter.check(fullReceiptFormatter, receipt));
 };


### PR DESCRIPTION
## Change
added exitReason to receipt, although it's not directly required by standard receipt, subql need to store it. Other places might also need it, so inclulded this free info.

Could potentially be useful for #453 

## Test
updated receipt snapshot, all prev tests still pass