### PR TITLE
enhanced parseblock and subql

### DIFF
--- a/bodhi/src/Signer.ts
+++ b/bodhi/src/Signer.ts
@@ -269,7 +269,9 @@ export class Signer extends Abstractsigner implements TypedDataSigner {
                   const hex = result.status.isInBlock
                     ? result.status.asInBlock.toHex()
                     : result.status.asFinalized.toHex();
-                  return this.provider.getTransactionReceiptAtBlock(extrinsic.hash.toHex(), hex);
+
+                  // tx was just mined so won't be null
+                  return this.provider.getReceiptAtBlockFromChain(extrinsic.hash.toHex(), hex) as Promise<TransactionReceipt>;
                 },
               });
             })

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1617,6 +1617,17 @@ export abstract class BaseProvider extends AbstractProvider {
     };
   };
 
+  getReceiptAtBlockFromChain = async (
+    txHash: string | Promise<string>,
+    _blockTag: BlockTag | Promise<BlockTag> | Eip1898BlockTag,
+  ): Promise<TransactionReceipt | null> => {
+    const blockTag = await this._ensureSafeModeBlockTagFinalization(await parseBlockTag(_blockTag));
+    const blockHash = await this._getBlockHash(blockTag);
+
+    const receipt = (await getAllReceiptsAtBlock(this.api, blockHash, await txHash))[0];
+    return receipt ?? null;
+  }
+
   getTransactionReceiptAtBlock = async (
     hashOrNumber: number | string | Promise<string>,
     _blockTag: BlockTag | Promise<BlockTag> | Eip1898BlockTag

--- a/eth-providers/src/base-provider.ts
+++ b/eth-providers/src/base-provider.ts
@@ -1344,11 +1344,13 @@ export abstract class BaseProvider extends AbstractProvider {
             const blockNumber = head.number.toNumber();
 
             if ((confirms as number) <= blockNumber - startBlock + 1) {
-              const receipt = this.getTransactionReceiptAtBlock(hash, startBlockHash);
+              const receipt = this.getReceiptAtBlockFromChain(hash, startBlockHash);
               if (alreadyDone()) {
                 return;
               }
-              resolve(receipt);
+
+              // tx was just mined so won't be null
+              resolve(receipt as Promise<TransactionReceipt>);
             }
           })
           .then((unsubscribe) => {

--- a/eth-providers/src/utils/subqlProvider.ts
+++ b/eth-providers/src/utils/subqlProvider.ts
@@ -1,6 +1,6 @@
 import { Log } from '@ethersproject/abstract-provider';
 import { request, gql } from 'graphql-request';
-import { Query, _Metadata, TransactionReceipt as TXReceiptGQL, Log as LogGQL } from './gqlTypes';
+import { Query, _Metadata, TransactionReceipt as TxReceiptGQL, Log as LogGQL } from './gqlTypes';
 import { logger } from './logger';
 import { buildLogsGqlFilter, adaptLogs, LOGS_NODES, TX_RECEIPT_NODES, SanitizedLogFilter } from './logs';
 
@@ -30,7 +30,7 @@ export class SubqlProvider {
       `
     );
 
-  getAllTxReceipts = async (): Promise<TXReceiptGQL[]> => {
+  getAllTxReceipts = async (): Promise<TxReceiptGQL[]> => {
     const res = await this.queryGraphql(`
       query {
         transactionReceipts {
@@ -39,10 +39,10 @@ export class SubqlProvider {
       }
     `);
 
-    return res.transactionReceipts!.nodes as TXReceiptGQL[];
+    return res.transactionReceipts!.nodes as TxReceiptGQL[];
   };
 
-  getTxReceiptByHash = async (hash: string): Promise<TXReceiptGQL | null> => {
+  getTxReceiptByHash = async (hash: string): Promise<TxReceiptGQL | null> => {
     const res = await this.queryGraphql(`
       query {
         transactionReceipts(filter: {
@@ -56,6 +56,22 @@ export class SubqlProvider {
     `);
 
     return res.transactionReceipts!.nodes[0] || null;
+  };
+
+  getAllReceiptsAtBlock = async (hash: string): Promise<TxReceiptGQL[]> => {
+    const res = await this.queryGraphql(`
+      query {
+        transactionReceipts(filter: {
+          blockHash:{
+            equalTo: "${hash}"
+          }
+        }) {
+          ${TX_RECEIPT_NODES}
+        }
+      }
+    `);
+
+    return res.transactionReceipts!.nodes as TxReceiptGQL[];
   };
 
   getAllLogs = async (): Promise<Log[]> => {


### PR DESCRIPTION
#656 is too big and I am gonna break it to a couple smaller self-contained pieces, so it's more reviewable.

## Change
Added a param `targetTxHash` for `getAllReceiptsAtBlock`, so that it can be used to find a single target receipt. Note that the performance should be much better than "first calling getAllReceiptsAtBlock to get all receipts, then filter out the target one".

Although in most cases for RPC we use subql/cache for receipt, a couple methods still require no latency. So we added a new method `getReceiptAtBlockFromChain` in baseProvider to for this. (which is basically what old `getTransactionReceiptAtBlock` does)

Also added a subql method to fetch all receipts at a block, which will be used later.

## Test
still pass