### PR TITLE
code polish

### DIFF
--- a/eth-providers/src/utils/utils.ts
+++ b/eth-providers/src/utils/utils.ts
@@ -77,24 +77,26 @@ export const promiseWithTimeout = <T = any>(value: any, interval = 1000): Promis
 export const runWithRetries = async <F extends AnyFunction>(
   fn: F,
   args: any[] = [],
-  maxRetries: number = 20,
-  interval: number = 1000
+  maxRetries: number = 50,
+  interval: number = 200
 ): Promise<F extends (...args: any[]) => infer R ? R : never> => {
   let res;
   let tries = 0;
 
   while (!res && tries++ < maxRetries) {
-    try {
-      res = await fn(...args);
-    } catch (e) {
-      if (tries === maxRetries) throw e;
-    }
+    res = await fn(...args);
 
-    if ((tries === 1 || tries % 10 === 0) && !res) {
-      console.log(`<local mode runWithRetries> still waiting for result # ${tries}/${maxRetries}`);
-    }
+    if (res) {
+      return res;
+    } else {
+      if (tries === maxRetries) return res;
 
-    await sleep(interval);
+      if ((tries === 1 || tries % 10 === 0) && !res) {
+        console.log(`<local mode runWithRetries> still waiting for result # ${tries}/${maxRetries}`);
+      }
+
+      await sleep(interval);
+    }
   }
 
   return res;


### PR DESCRIPTION
## Change
some structure polish, updated local mode `runWithRetires` to accommodate new behavior that when receipt not found, we don't throw error anymore.

fixes #626, it's actually not state_call's issue. it's runWithRetires somehow delayed result return, not sure why it worked before though. But now it doesn't have this issue anymore, local mode is as fast as it should

## Test
still pass