### PR TITLE
fix metamask send token gaslimit

### DIFF
--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -984,7 +984,8 @@ export abstract class BaseProvider extends AbstractProvider {
       ? BigNumber.from(tx.gasPrice)
       : await this.getGasPrice();
 
-    return encodeGasLimit(txFee, gasPrice, gasLimit, usedStorage);
+    const isTokenTransfer = hexlify(await transaction.data ?? '').startsWith('0xa9059cbb');  // transfer(address,uint256)
+    return encodeGasLimit(txFee, gasPrice, gasLimit, usedStorage, isTokenTransfer);
   };
 
   _estimateGasCost = async (extrinsic: SubmittableExtrinsic<'promise', ISubmittableResult>) => {

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -53,6 +53,7 @@ import {
   GAS_LIMIT_CHUNK,
   GAS_MASK,
   LOCAL_MODE_MSG,
+  MAX_GAS_LIMIT_CC,
   ONE_HUNDRED_GWEI,
   PROD_MODE_MSG,
   RICH_MODE_WARNING_MSG,
@@ -1294,7 +1295,7 @@ export abstract class BaseProvider extends AbstractProvider {
         }
         gasLimit = encodedGasLimit.mul(GAS_LIMIT_CHUNK).toBigInt();
         storageLimit = BigNumber.from(2)
-          .pow(encodedStorageLimit.gt(20) ? 20 : encodedStorageLimit)
+          .pow(encodedStorageLimit.gt(MAX_GAS_LIMIT_CC) ? MAX_GAS_LIMIT_CC : encodedStorageLimit)
           .toBigInt();
       }
     } else if (ethTx.type === 1 || ethTx.type === 2) {

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -985,7 +985,7 @@ export abstract class BaseProvider extends AbstractProvider {
       : await this.getGasPrice();
 
     const tokenTransferSelector = '0xa9059cbb';   // transfer(address,uint256)
-    const isTokenTransfer = hexlify(await transaction.data ?? '').startsWith(tokenTransferSelector);
+    const isTokenTransfer = hexlify(await transaction.data ?? '0x').startsWith(tokenTransferSelector);
     return encodeGasLimit(txFee, gasPrice, gasLimit, usedStorage, isTokenTransfer);
   };
 

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -984,7 +984,8 @@ export abstract class BaseProvider extends AbstractProvider {
       ? BigNumber.from(tx.gasPrice)
       : await this.getGasPrice();
 
-    const isTokenTransfer = hexlify(await transaction.data ?? '').startsWith('0xa9059cbb');  // transfer(address,uint256)
+    const tokenTransferSelector = '0xa9059cbb';   // transfer(address,uint256)
+    const isTokenTransfer = hexlify(await transaction.data ?? '').startsWith(tokenTransferSelector);
     return encodeGasLimit(txFee, gasPrice, gasLimit, usedStorage, isTokenTransfer);
   };
 

--- a/packages/eth-providers/src/consts.ts
+++ b/packages/eth-providers/src/consts.ts
@@ -89,6 +89,7 @@ export const ORPHAN_TX_DEFAULT_INFO = {
 
 export const BLOCK_GAS_LIMIT = 29_990_016;
 export const BLOCK_STORAGE_LIMIT = 3_670_016;
+export const MAX_GAS_LIMIT_CC = 22;  // log2(BLOCK_STORAGE_LIMIT)
 
 export const ONE_GWEI = 1_000_000_000n;
 export const TEN_GWEI = ONE_GWEI * 10n;

--- a/packages/eth-providers/src/consts.ts
+++ b/packages/eth-providers/src/consts.ts
@@ -89,7 +89,7 @@ export const ORPHAN_TX_DEFAULT_INFO = {
 
 export const BLOCK_GAS_LIMIT = 29_990_016;
 export const BLOCK_STORAGE_LIMIT = 3_670_016;
-export const MAX_GAS_LIMIT_CC = 22;  // log2(BLOCK_STORAGE_LIMIT)
+export const MAX_GAS_LIMIT_CC = 21;  // log2(BLOCK_STORAGE_LIMIT)
 
 export const ONE_GWEI = 1_000_000_000n;
 export const TEN_GWEI = ONE_GWEI * 10n;

--- a/packages/eth-providers/src/utils/transactionHelper.ts
+++ b/packages/eth-providers/src/utils/transactionHelper.ts
@@ -135,7 +135,7 @@ export const encodeGasLimit = (
     // so when metamask 1.5X gasLimit, it won't affect cc
     encodedGasLimit = encodedGasLimit.mod(2).eq(0)
       ? encodedGasLimit
-      : encodedGasLimit.add(1);
+      : encodedGasLimit.div(10).add(1).mul(10);
   }
 
   const aaaa00000 = rawEthGasLimit.gt(GAS_MASK)

--- a/packages/eth-providers/src/utils/transactionHelper.ts
+++ b/packages/eth-providers/src/utils/transactionHelper.ts
@@ -131,9 +131,8 @@ export const encodeGasLimit = (
 
   let encodedGasLimit = gasLimit.div(GAS_LIMIT_CHUNK).add(1);
   if (isTokenTransfer) {
-    // for token transfer, need to make sure bbb is even
-    // so when metamask 1.5X gasLimit, it won't affect cc
-    // bbb => bb0
+    // for token transfer, need to make sure when metamask 1.5X gasLimit, it won't affect cc
+    // bbb => b(b+1)0
     encodedGasLimit = encodedGasLimit.div(10).add(1).mul(10);
   }
 

--- a/packages/eth-providers/src/utils/transactionHelper.ts
+++ b/packages/eth-providers/src/utils/transactionHelper.ts
@@ -121,16 +121,28 @@ export const encodeGasLimit = (
   txFee: BigNumber,
   gasPrice: BigNumber,
   gasLimit: BigNumber,
-  usedStorage: BigNumber
+  usedStorage: BigNumber,
+  isTokenTransfer = false,
 ): BigNumber => {
   const rawEthGasLimit = txFee.div(gasPrice);
-  const encodedGasLimit = gasLimit.div(GAS_LIMIT_CHUNK).add(1);
-  const encodedStorageLimit = usedStorage.gt(0) ? Math.ceil(Math.log2(usedStorage.toNumber())) : 0;
+  const encodedStorageLimit = usedStorage.gt(0)
+    ? Math.ceil(Math.log2(usedStorage.toNumber()))
+    : 0;
+
+  let encodedGasLimit = gasLimit.div(GAS_LIMIT_CHUNK).add(1);
+  if (isTokenTransfer) {
+    // for token transfer, need to make sure bbb is even
+    // so when metamask 1.5X gasLimit, it won't affect cc
+    encodedGasLimit = encodedGasLimit.mod(2).eq(0)
+      ? encodedGasLimit
+      : encodedGasLimit.add(1);
+  }
 
   const aaaa00000 = rawEthGasLimit.gt(GAS_MASK)
     ? rawEthGasLimit.div(GAS_MASK).mul(GAS_MASK)
     : BigNumber.from(GAS_MASK);
   const bbb00 = encodedGasLimit.mul(STORAGE_MASK);
   const cc = encodedStorageLimit;
+
   return aaaa00000.add(bbb00).add(cc); // aaaabbbcc
 };

--- a/packages/eth-providers/src/utils/transactionHelper.ts
+++ b/packages/eth-providers/src/utils/transactionHelper.ts
@@ -133,9 +133,8 @@ export const encodeGasLimit = (
   if (isTokenTransfer) {
     // for token transfer, need to make sure bbb is even
     // so when metamask 1.5X gasLimit, it won't affect cc
-    encodedGasLimit = encodedGasLimit.mod(2).eq(0)
-      ? encodedGasLimit
-      : encodedGasLimit.div(10).add(1).mul(10);
+    // bbb => bb0
+    encodedGasLimit = encodedGasLimit.div(10).add(1).mul(10);
   }
 
   const aaaa00000 = rawEthGasLimit.gt(GAS_MASK)


### PR DESCRIPTION
## Context
a long time ago, some random metamask user said: "I tried to transfer token via MM, but failed due to gas underestimation". MM engineers only have 2 hours to solve this issue, so they made a fastest decision: simply 1.5X gasLimit for ALL token transfer, for ALL networks ¯\_(ツ)_/¯

## Change
This occasionally causes our new gas system to fail. For example when bbbcc = 00300, after 1.5X it becomes 00450, which correspond to storageLimit of 2^50.

Since this is a very corner case (only happens when directly transfer token via MM), the easiest workaround is to make sure bbb is even, so after 1.5X it won't affect cc. In the above example, when modify bbbcc from 00300 => 00400, after 1.5X it's 00600, cc is not affected.

## Test
tested locally connecting to karura testnet, and previous failing MM token transfer works