### PR TITLE
fix bodhi export

### DIFF
--- a/examples/waffle/run.sh
+++ b/examples/waffle/run.sh
@@ -31,3 +31,5 @@ for e in "${examples[@]}"
 echo "+++++++++++++++++++++++"
 echo "test failed: $failed"
 echo "+++++++++++++++++++++++"
+
+exit $failed

--- a/packages/bodhi/src/index.ts
+++ b/packages/bodhi/src/index.ts
@@ -1,5 +1,4 @@
 export { BodhiProvider } from '@acala-network/eth-providers';
 export * from './BodhiSigner';
 export * from './SubstrateSigner';
-export * from './evmChai';
 export * from './utils';

--- a/packages/bodhi/tsconfig.json
+++ b/packages/bodhi/tsconfig.json
@@ -5,6 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "lib", "src/__tests__"],
+  "exclude": ["node_modules", "lib", "src/__tests__", "src/evmChai"],
   "references": [{ "path": "../eth-providers" }]
 }

--- a/packages/eth-providers/package.json
+++ b/packages/eth-providers/package.json
@@ -40,6 +40,7 @@
     "@types/lru-cache": "~7.6.1",
     "dotenv": "~10.0.0",
     "jsdom": "^22.0.0",
+    "typescript": "~4.6.3",
     "vitest": "^0.31.0"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,6 +95,7 @@ __metadata:
     graphql-request: ~3.6.1
     jsdom: ^22.0.0
     lru-cache: ~7.8.2
+    typescript: ~4.6.3
     vitest: ^0.31.0
   peerDependencies:
     "@acala-network/api": ~5.1.1


### PR DESCRIPTION
## Change
excluded `evmchai` from export, so that other packages that uses bodhi won't need to install chai

fix #758 

## Test
tested local build and works now

