### PR TITLE
fix `eth_getLogs` for latest block timing issue

### DIFF
--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1785,8 +1785,8 @@ export abstract class BaseProvider extends AbstractProvider {
 
     const subqlLogs = await this.subql.getFilteredLogs(filter);   // only filtered by blockNumber and address
     return subqlLogs
-      .filter((log) => filterLogByTopics(log, filter.topics))
-      .map(this.formatter.filterLog);
+      .filter(log => filterLogByTopics(log, filter.topics))
+      .map(log => this.formatter.filterLog(log));
   };
 
   getIndexerMetadata = async (): Promise<_Metadata | undefined> => {

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1777,8 +1777,12 @@ export abstract class BaseProvider extends AbstractProvider {
     const filter = await this._sanitizeRawFilter(rawFilter);
 
     // make sure subql already indexed all target blocks
+    const bestBlock = await this.bestBlockNumber;
+    const targetBlock = filter.toBlock <= bestBlock
+      ? filter.toBlock
+      : bestBlock;
     let lastProcessedHeight = await this.subql.getLastProcessedHeight();
-    while (lastProcessedHeight < filter.toBlock) {
+    while (lastProcessedHeight < targetBlock) {
       await sleep(1000);
       lastProcessedHeight = await this.subql.getLastProcessedHeight();
     }

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -92,6 +92,7 @@ import {
   runWithRetries,
   runWithTiming,
   sendTx,
+  sleep,
   sortObjByKey,
   subqlReceiptAdapter,
   throwNotImplemented,
@@ -1774,10 +1775,18 @@ export abstract class BaseProvider extends AbstractProvider {
     }
 
     const filter = await this._sanitizeRawFilter(rawFilter);
-    const subqlLogs = await this.subql.getFilteredLogs(filter); // only filtered by blockNumber and address
-    const filteredLogs = subqlLogs.filter((log) => filterLogByTopics(log, filter.topics));
 
-    return filteredLogs.map((log) => this.formatter.filterLog(log));
+    // make sure subql already indexed all target blocks
+    let lastProcessedHeight = await this.subql.getLastProcessedHeight();
+    while (lastProcessedHeight < filter.toBlock) {
+      await sleep(1000);
+      lastProcessedHeight = await this.subql.getLastProcessedHeight();
+    }
+
+    const subqlLogs = await this.subql.getFilteredLogs(filter);   // only filtered by blockNumber and address
+    return subqlLogs
+      .filter((log) => filterLogByTopics(log, filter.topics))
+      .map(this.formatter.filterLog);
   };
 
   getIndexerMetadata = async (): Promise<_Metadata | undefined> => {

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1776,11 +1776,11 @@ export abstract class BaseProvider extends AbstractProvider {
 
     const filter = await this._sanitizeRawFilter(rawFilter);
 
-    // make sure subql already indexed all target blocks
-    const bestBlock = await this.bestBlockNumber;
-    const targetBlock = filter.toBlock <= bestBlock
+    // make sure subql already indexed all target blocks, up until the latest finalized block
+    const upperBoundry = await this.finalizedBlockNumber;
+    const targetBlock = filter.toBlock <= upperBoundry
       ? filter.toBlock
-      : bestBlock;
+      : upperBoundry;
     let lastProcessedHeight = await this.subql.getLastProcessedHeight();
     while (lastProcessedHeight < targetBlock) {
       await sleep(1000);

--- a/packages/eth-providers/src/utils/subqlProvider.ts
+++ b/packages/eth-providers/src/utils/subqlProvider.ts
@@ -22,6 +22,11 @@ export class SubqlProvider {
     return metaData?.genesisHash as string;
   };
 
+  getLastProcessedHeight = async (): Promise<number> => {
+    const metaData = await this.getIndexerMetadata();
+    return metaData?.lastProcessedHeight ?? 0;
+  };
+
   queryGraphql = (query: string): Promise<Query> =>
     request(
       this.url,


### PR DESCRIPTION
## Issue
when query logs for a block as soon as it's finalized, it will return empty logs since subql is still indexing this block. This is usually fine but breaks subquery log handlers, which exactly queries logs for a block as soon as it's finalized.

## Change
adds a check for get logs to make sure it waits until the indexer finished indexing required range, since now we don't support unfinalized logs, so the upper bound is latest finalized log.

## Test
did some manual test locally, and the subql issue seems to be gone
