### PR TITLE
added subql sync check for get receipt

### DIFF
--- a/examples/waffle/e2e/test/dex.test.ts
+++ b/examples/waffle/e2e/test/dex.test.ts
@@ -86,7 +86,7 @@ describe('dex test', () => {
 
     const txHash = swapWithExactSupplyExtrinsic.hash.toHex();
     const tx = await evmProvider.getTransactionByHash(txHash);
-    const receipt = await evmProvider.getReceiptByHash(txHash);
+    const receipt = await evmProvider.getReceipt(txHash);
 
     const aliceEvmAddress = (await wallet.getAddress()).toLowerCase();
     expect(hexlifyRpcResult(tx)).to.contain({

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1804,6 +1804,8 @@ export abstract class BaseProvider extends AbstractProvider {
      so upper bound would be finalized block number
                                                  ---------- */
   _waitForSubql = async (_targetBlock: number) => {
+    if (!this.subql) return;
+
     const SUBQL_MAX_WAIT_BLOCKS = 3;
 
     const upperBound = await this.finalizedBlockNumber;

--- a/packages/eth-providers/src/utils/BlockCache.ts
+++ b/packages/eth-providers/src/utils/BlockCache.ts
@@ -42,13 +42,14 @@ export class BlockCache {
     }
   };
 
-  getReceiptByHash = (txHash: string): FullReceipt | null => this.txHashToReceipt[txHash] ?? null;
+  getReceiptByHash = (txHash: string): FullReceipt | null =>
+    this.txHashToReceipt[txHash] ?? null;
 
-  getAllReceiptsAtBlock = (blockHash: string): FullReceipt[] => this.blockHashToReceipts[blockHash] ?? [];
+  getAllReceiptsAtBlock = (blockHash: string): FullReceipt[] =>
+    this.blockHashToReceipts[blockHash] ?? [];
 
-  getReceiptAtBlock = (txHash: string, blockHash: string): FullReceipt | null => {
-    return this.getAllReceiptsAtBlock(blockHash).find((r) => r.transactionHash === txHash) ?? null;
-  };
+  getReceiptAtBlock = (txHash: string, blockHash: string): FullReceipt | null =>
+    this.getAllReceiptsAtBlock(blockHash).find((r) => r.transactionHash === txHash) ?? null;
 
   inspect = (): CacheInspect => ({
     maxCachedBlocks: this.maxCachedBlocks,

--- a/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -611,7 +611,7 @@ describe('endpoint', () => {
         await Promise.all(pendings.map(p => p.wait()));
 
         const res = await eth_getLogs([{ fromBlock: curblockNum + 5, toBlock: curblockNum + 5 }]);
-        expect(res.data.error?.message).to.contain('Error: subql is not synced with the target block range, please wait for the indexer to catch up');
+        expect(res.data.error?.message).to.contain('Error: subql indexer is not synced to target block');
       });
     });
   });

--- a/packages/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/packages/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -333,7 +333,7 @@ class Eip1193BridgeImpl {
   async eth_getTransactionReceipt(params: any[]): Promise<TransactionReceipt | null> {
     validate([{ type: 'blockHash' }], params);
 
-    const res = await this.#provider.getReceiptByHash(params[0]);
+    const res = await this.#provider.getReceipt(params[0]);
     if (!res) return null;
 
     // @ts-ignore


### PR DESCRIPTION
## Change
Although it's a super rare case, but if there is a gap between subql and block cache (for instance, subql is 250 blocks delayed), RPC will return falsy `null` for a txHash in that gap. This commit adds a check to make sure subql is synced to at least the lower bound of block cache to prevent such issue.

Also did some renaming to make them more concise:
- `getReceiptByHash` => `getReceipt`
- `_getMinedReceipt` => `_getReceipt`

## Test
no test. It's pretty hard to setup such corner case ...