### PR TITLE
add net_listening

### DIFF
--- a/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -63,6 +63,7 @@ import {
   getCurBlockHash,
   getNonce,
   RPC_URL,
+  net_listening,
 } from './utils';
 
 import {
@@ -2110,5 +2111,12 @@ describe('endpoint', () => {
     // too lazy to test these
     it.skip('eth_call', async () => {});
     it.skip('eth_getStorageAt', async () => {});
+  });
+
+  describe('net_listening', () => {
+    it('returns true', async () => {
+      const res = (await net_listening([])).data.result;
+      expect(res).to.deep.equal(true);
+    });
   });
 });

--- a/packages/eth-rpc-adapter/src/__tests__/e2e/utils.ts
+++ b/packages/eth-rpc-adapter/src/__tests__/e2e/utils.ts
@@ -62,6 +62,7 @@ export const eth_getFilterLogs = rpcGet<{
   }
 }>('eth_getFilterLogs');
 export const eth_uninstallFilter = rpcGet('eth_uninstallFilter');
+export const net_listening = rpcGet('net_listening');
 
 /* ---------- karura mainnet rpc methods ---------- */
 export const eth_blockNumber_karura = rpcGet('eth_blockNumber', KARURA_ETH_RPC_URL);

--- a/packages/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/packages/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -77,6 +77,11 @@ class Eip1193BridgeImpl {
     return this.#provider.healthCheck();
   }
 
+  async net_listening(params: any[]): Promise<boolean> {
+    validate([], params);
+    return true;
+  }
+
   // TODO: maybe can encapsulate all provider info into one call `net_Info` or something
   async net_runtimeVersion(params: any[]) {
     validate([], params);


### PR DESCRIPTION
## Change
added `net_listening` RPC. It seems to be a dummy RPC for us, since I can't think of any senario that we don't want to accept connection.

Should we check RPC health first, and return `false` when unhealthy? But in many cases, most functionalities still work even for unhealthy RPC (such as subquery delayed), I am not sure if we want no connection at all in this case

fix #253 

## Test
added dummy test for it, just to make sure the RPC exist