### PR TITLE
fix dd operation name 

### DIFF
--- a/packages/eth-providers/src/base-provider-dd.ts
+++ b/packages/eth-providers/src/base-provider-dd.ts
@@ -72,8 +72,8 @@ export class BaseProviderWithTrace extends BaseProvider {
       }
 
       this[methodName] = tracer.wrap(
-        `provider.${methodName}`,
-        { resource: methodName },
+        'provider_call',
+        { resource: `provider.${methodName}` },
         this[methodName].bind(this)
       );
     }

--- a/packages/eth-rpc-adapter/package.json
+++ b/packages/eth-rpc-adapter/package.json
@@ -9,7 +9,7 @@
     "build": "tsc --build tsconfig.json",
     "test:e2e": "vitest --run --config vitest.config.e2e.ts",
     "start": "ts-node -r tsconfig-paths/register src/index.ts",
-    "dev": "ts-node-dev -T -r tsconfig-paths/register src/index.ts -l | pino-pretty --singleLine --colorize --ignore time,hostname,jsonrpc",
+    "dev": "ts-node-dev -T -r tsconfig-paths/register src/index.ts -l | pino-pretty --singleLine --colorize --ignore time,hostname,jsonrpc,dd",
     "test:CI": "vitest --run --config vitest.config.e2e.ts",
     "ncc:pack": "ncc build src/index.ts -t --target es2020"
   },

--- a/packages/eth-rpc-adapter/src/router.ts
+++ b/packages/eth-rpc-adapter/src/router.ts
@@ -17,7 +17,7 @@ export class Router {
     if (this.#bridge.isMethodImplemented(methodName)) {
       try {
         const result = await tracer.trace(
-          `router_call.<${methodName}>`,
+          'eth_rpc_call',
           { resource: methodName },
           () => this.#bridge.send(methodName, params, ws)
         );


### PR DESCRIPTION
## Change
previously all traces are not groupable, so it's hard to see an overview. This PR fixed dd operation name so that dd UI can group traces by top level `eth_rpc_call` or second level `provider_call`

## Test
deployed to dev and now can see an overview
<img width="1626" alt="Screenshot 2023-10-07 at 14 07 34" src="https://github.com/AcalaNetwork/bodhi.js/assets/16548786/5a8ab45a-7311-456a-9d9a-1e008ae3311f">
