### PR TITLE
fix dd trace log and trace correlation

### DIFF
--- a/packages/eth-rpc-adapter/Dockerfile
+++ b/packages/eth-rpc-adapter/Dockerfile
@@ -13,7 +13,7 @@ RUN unlink /usr/bin/python && \
 
 COPY . .
 RUN yarn install --immutable
-RUN yarn workspace @acala-network/eth-rpc-adapter ncc:pack
+RUN yarn build
 
 
 # =============
@@ -21,9 +21,22 @@ RUN yarn workspace @acala-network/eth-rpc-adapter ncc:pack
 FROM node:16-alpine
 LABEL maintainer="hello@acala.network"
 
-COPY --from=builder /app/packages/eth-rpc-adapter/dist /app
+COPY --from=builder /app/package.json /app/.yarnrc.yml /app/
+COPY --from=builder /app/node_modules /app/node_modules
 
-WORKDIR /app
+COPY --from=builder /app/packages/eth-rpc-adapter/package.json /app/packages/eth-rpc-adapter/package.json
+COPY --from=builder /app/packages/eth-transactions/package.json /app/packages/eth-transactions/package.json
+COPY --from=builder /app/packages/eth-providers/package.json /app/packages/eth-providers/package.json
+
+COPY --from=builder /app/packages/eth-rpc-adapter/lib /app/packages/eth-rpc-adapter/lib
+COPY --from=builder /app/packages/eth-transactions/lib /app/packages/eth-transactions/lib
+COPY --from=builder /app/packages/eth-providers/lib /app/packages/eth-providers/lib
+
+COPY --from=builder /app/packages/eth-rpc-adapter/node_modules /app/packages/eth-rpc-adapter/node_modules
+COPY --from=builder /app/packages/eth-transactions/node_modules /app/packages/eth-transactions/node_modules
+# COPY --from=builder /app/packages/eth-providers/node_modules /app/packages/eth-providers/node_modules
+
+WORKDIR /app/packages/eth-rpc-adapter
 
 EXPOSE 8545
 
@@ -31,4 +44,4 @@ USER node
 
 ENV NODE_ENV=production
 
-ENTRYPOINT ["node", "index.js" ]
+ENTRYPOINT ["node", "lib/index.js"]

--- a/packages/eth-rpc-adapter/Dockerfile
+++ b/packages/eth-rpc-adapter/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=builder /app/packages/eth-providers/lib /app/packages/eth-providers/
 
 COPY --from=builder /app/packages/eth-rpc-adapter/node_modules /app/packages/eth-rpc-adapter/node_modules
 COPY --from=builder /app/packages/eth-transactions/node_modules /app/packages/eth-transactions/node_modules
-# COPY --from=builder /app/packages/eth-providers/node_modules /app/packages/eth-providers/node_modules
+# COPY --from=builder /app/packages/eth-providers/node_modules /app/packages/eth-providers/node_modules     # don't exist
 
 WORKDIR /app/packages/eth-rpc-adapter
 

--- a/packages/eth-rpc-adapter/src/router.ts
+++ b/packages/eth-rpc-adapter/src/router.ts
@@ -6,7 +6,7 @@ import tracer from 'dd-trace';
 import { Eip1193Bridge } from './eip1193-bridge';
 import { InternalError, InvalidParams, JSONRPCError, MethodNotFound } from './errors';
 import { JsonRpcResponse } from './server';
-import { shouldTraceEthRpc } from './utils/datadog';
+import { shouldNotTrace } from './utils/datadog';
 export class Router {
   readonly #bridge: Eip1193Bridge;
 
@@ -17,7 +17,7 @@ export class Router {
   public async call(methodName: string, params: unknown[], ws?: WebSocket): Promise<Partial<JsonRpcResponse>> {
     if (this.#bridge.isMethodImplemented(methodName)) {
       try {
-        const result = !shouldTraceEthRpc(methodName)
+        const result = shouldNotTrace(methodName)
           ? await this.#bridge.send(methodName, params, ws)
           : await tracer.trace(
             'eth_rpc_call',

--- a/packages/eth-rpc-adapter/src/server.ts
+++ b/packages/eth-rpc-adapter/src/server.ts
@@ -158,7 +158,7 @@ export default class EthRpcServer {
   }
 
   private async httpHandler(req: any, res: http.ServerResponse, next: (err?: any) => void): Promise<void> {
-    logger.debug(req.body, 'incoming request');
+    logger.debug(req.body, '⬇ request');
 
     let result = null;
     try {
@@ -175,7 +175,7 @@ export default class EthRpcServer {
       return next(e);
     }
 
-    logger.debug(result, 'request completed');
+    logger.debug(result, '✨ response');
 
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(result));
@@ -197,7 +197,7 @@ export default class EthRpcServer {
       return;
     }
 
-    logger.debug(req, 'ws incoming request');
+    logger.debug(req, '⬇ ws request');
 
     let result = null;
 
@@ -214,7 +214,7 @@ export default class EthRpcServer {
       result = await this.baseHandler(req, ws);
     }
 
-    logger.debug(result, 'ws request completed');
+    logger.debug(result, '⭐ ws response');
 
     ws.send(JSON.stringify(result));
   }

--- a/packages/eth-rpc-adapter/src/utils/datadog.ts
+++ b/packages/eth-rpc-adapter/src/utils/datadog.ts
@@ -1,0 +1,4 @@
+export const DONT_TRACE_ETH_RPCS = ['net_health'];
+
+// we can also config these in dd agent, but with code it is more flexible
+export const shouldTraceEthRpc = (ethRpcName: string) => DONT_TRACE_ETH_RPCS.includes(ethRpcName);

--- a/packages/eth-rpc-adapter/src/utils/datadog.ts
+++ b/packages/eth-rpc-adapter/src/utils/datadog.ts
@@ -1,4 +1,4 @@
 export const DONT_TRACE_ETH_RPCS = ['net_health'];
 
 // we can also config these in dd agent, but with code it is more flexible
-export const shouldTraceEthRpc = (ethRpcName: string) => DONT_TRACE_ETH_RPCS.includes(ethRpcName);
+export const shouldNotTrace = (ethRpcName: string) => DONT_TRACE_ETH_RPCS.includes(ethRpcName);


### PR DESCRIPTION
## Change
- the `ncc` bundler messed up dd trace, so that logs can't correlate with traces ([reference](https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/nodejs/#bundling)). So we switched back to tsc build, which should still be sufficient for performance, since the code execution time (1ms) is relatively trivial compared to the ajax time (200+ ms each) in our case. The only draw back is the image size increases from 40 to 240 Mb, which is acceptable.
- skipped `net_health` trace, which takes a long time and thus impacts time scale in DD UI
- polished request and response logging so it's clearer in visulization

fix #857 

## Test
deployed to mandala:
- can find correlate traces for logs
- can find correlated logs for traces
- now there appears be many more layers of tracking, which were auto injected by DD for node apps
- version tagging is now enabled

![Screenshot 2023-10-10 at 11 06 41](https://github.com/AcalaNetwork/bodhi.js/assets/16548786/2df7c52e-8439-4acf-b840-b43dc3a8ca06)
![Screenshot 2023-10-10 at 11 10 28](https://github.com/AcalaNetwork/bodhi.js/assets/16548786/7b9e3685-6a72-409a-8d45-d9626b24a40a)


