### PR TITLE
add dd-trace export

### DIFF
--- a/packages/eth-providers/package.json
+++ b/packages/eth-providers/package.json
@@ -17,6 +17,7 @@
     "@acala-network/contracts": "4.3.4",
     "@acala-network/eth-transactions": "workspace:*",
     "bn.js": "~5.2.0",
+    "dd-trace": "~4.16.0",
     "ethers": "~5.7.0",
     "graphql": "~16.0.1",
     "graphql-request": "~3.6.1",
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@acala-network/api": "~6.0.0",
     "@types/bn.js": "~5.1.0",
+    "@types/dd-trace": "^0.9.0",
     "@types/lru-cache": "~7.6.1",
     "dotenv": "~10.0.0",
     "jsdom": "^22.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,8 +73,10 @@ __metadata:
     "@acala-network/contracts": 4.3.4
     "@acala-network/eth-transactions": "workspace:*"
     "@types/bn.js": ~5.1.0
+    "@types/dd-trace": ^0.9.0
     "@types/lru-cache": ~7.6.1
     bn.js: ~5.2.0
+    dd-trace: ~4.16.0
     dotenv: ~10.0.0
     ethers: ~5.7.0
     graphql: ~16.0.1


### PR DESCRIPTION
Added `dd-trace` deps to eth-providers, which should fix the `module not found` error when other packages import eth-provider.

Note that it's just a package resolution level thing, so dd trace won't actually be enabled unless user explicitly imports and use `EvmRpcProviderWithTrace`

fix #872 