### PR TITLE
fix evm invaldCode error reporting

### DIFF
--- a/packages/eth-providers/package.json
+++ b/packages/eth-providers/package.json
@@ -24,7 +24,7 @@
     "lru-cache": "~7.8.2"
   },
   "devDependencies": {
-    "@acala-network/api": "~6.0.0",
+    "@acala-network/api": "^6.0.3",
     "@types/bn.js": "~5.1.0",
     "@types/dd-trace": "^0.9.0",
     "@types/lru-cache": "~7.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,26 +12,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@acala-network/api-derive@npm:6.0.0":
-  version: 6.0.0
-  resolution: "@acala-network/api-derive@npm:6.0.0"
+"@acala-network/api-derive@npm:6.0.3":
+  version: 6.0.3
+  resolution: "@acala-network/api-derive@npm:6.0.3"
   dependencies:
-    "@acala-network/types": 6.0.0
+    "@acala-network/types": 6.0.3
   peerDependencies:
     "@polkadot/api": ^10.9.1
-  checksum: 8656e7b65bfef498cac780d7beb0d3e43a59b5343d09a8b28ce7ec3537494b7477b0162a01b4f6c53260cfa7fa63c59e311b3a254020da6a104832826e6099ed
+  checksum: 371c1a3b0d2cc980667a494ae12f04b7d57feab8f0a764a1ec71f2e58d60259f1a0fc663448c93cb51f673cd10120eb12b9d4ae3c1361fcebce815f0505852bf
   languageName: node
   linkType: hard
 
-"@acala-network/api@npm:~6.0.0":
-  version: 6.0.0
-  resolution: "@acala-network/api@npm:6.0.0"
+"@acala-network/api@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "@acala-network/api@npm:6.0.3"
   dependencies:
-    "@acala-network/api-derive": 6.0.0
-    "@acala-network/types": 6.0.0
+    "@acala-network/api-derive": 6.0.3
+    "@acala-network/types": 6.0.3
   peerDependencies:
     "@polkadot/api": ^10.9.1
-  checksum: 5ec48f880b80ad7a9acf070dbd90938e6aae8248407a283c19560e80b21179fae35f4e4d828d9f1ac300be4e119800ece834df2c96f02dbc35e73be1e83da8ad
+  checksum: 8d9f018e8780368f7cf62f8675d8895543ff632344607880a711b195f8234e046541cfb5a9a81abdaec1618dd6b00d36b1f00e6d26b5029886b46d1a4ae9a04e
   languageName: node
   linkType: hard
 
@@ -69,7 +69,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@acala-network/eth-providers@workspace:packages/eth-providers"
   dependencies:
-    "@acala-network/api": ~6.0.0
+    "@acala-network/api": ^6.0.3
     "@acala-network/contracts": 4.3.4
     "@acala-network/eth-transactions": "workspace:*"
     "@types/bn.js": ~5.1.0
@@ -150,12 +150,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@acala-network/types@npm:6.0.0":
-  version: 6.0.0
-  resolution: "@acala-network/types@npm:6.0.0"
+"@acala-network/types@npm:6.0.3":
+  version: 6.0.3
+  resolution: "@acala-network/types@npm:6.0.3"
   peerDependencies:
     "@polkadot/api": ^10.9.1
-  checksum: d5187f6eccf46e094cda7a69e23c6fd1f8221da4f1e7d30964c9769bb40795e0aa25c5a400c51b3ae4a2bb9dcc47996738febe08b7b4f2378ece7aa14461a74d
+  checksum: ce2ce43ae8cbfa155ef5f2811253cad9f19f3e32b1b7a71437c0741855dca3b1e16cc0e48ede2b46d7d256adfe3ff2b5f652cf0e8e2dc1803f5ef9aba6ac3659
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Change
update types to correctly report `invalidCode` evm revert

## Test
tested locally and can throw correct errors when using too new compiler on remix
```
{
  "jsonrpc":"2.0",
  "error":"execution error: invalidCode"
}
```