### PR TITLE
refactor e2e tests

### DIFF
--- a/scripts/e2e-tests/hardhat.config.ts
+++ b/scripts/e2e-tests/hardhat.config.ts
@@ -16,6 +16,11 @@ const config: HardhatUserConfig = {
       ...networkCommon,
       chainId: 595,
     },
+    mandalaPub: {
+      ...networkCommon,
+      url: 'https://eth-mandala.aca-staging.network',
+      chainId: 595,
+    },
     karura: {
       ...networkCommon,
       chainId: 686,

--- a/scripts/e2e-tests/package.json
+++ b/scripts/e2e-tests/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "hardhat compile",
+    "test:mandalaPub": "hardhat test --network mandalaPub",
     "test:mandala": "hardhat test --network mandala",
     "test:karura": "hardhat test --network karura",
     "test:acala": "hardhat test --network acala",

--- a/scripts/e2e-tests/test/utils.ts
+++ b/scripts/e2e-tests/test/utils.ts
@@ -1,0 +1,117 @@
+import { hexZeroPad } from 'ethers/lib/utils';
+import WebSocket from 'ws';
+
+export class SubsManager {
+  msgs: any[] = [];
+  ws: WebSocket;
+  isReady: Promise<void>;
+  id = 0;
+
+  constructor(url: string) {
+    this.ws = new WebSocket(url);
+
+    this.isReady = new Promise((resolve) => {
+      this.ws.on('open', () => {
+        this.ws.on('message', (data) => {
+          const parsedData = JSON.parse(data.toString());
+          this.msgs.push(parsedData);
+        });
+        resolve();
+      });
+    });
+  }
+
+  clear() {
+    this.msgs.length = 0;
+  }
+
+  buildRequest(id: number, params: any[]) {
+    return JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'eth_subscribe',
+      id,
+      params,
+    })
+  }
+
+  async waitForMsg(
+    subId: string,
+    filterFn = (_msg: any) => true,
+    timeout = 5000,
+  ) {
+    return new Promise<any>(resolve => {
+      const interval = setInterval(() => {
+        const msg = this.msgs
+          .filter(msg => msg.params?.subscription === subId)
+          .find(msg => filterFn(msg.params.result));
+
+        if (msg) {
+          clearInterval(interval);
+          resolve(msg);
+        }
+      }, 1000);
+
+      setTimeout(() => {
+        clearInterval(interval);
+        resolve(null);
+      }, timeout);
+    });
+  }
+
+  async waitForSubs(reqId: number) {
+    return new Promise<any>(resolve => {
+      const interval = setInterval(() => {
+        const msg = this.msgs.find(msg => msg.id === reqId)
+
+        if (msg) {
+          clearInterval(interval);
+          resolve(msg);
+        }
+      }, 1000);
+    });
+  }
+
+  async subscribeNewHeads() {
+    const reqId = this.id++;
+
+    this.ws.send(
+      this.buildRequest(reqId, ['newHeads'])
+    );
+
+    const resp = await this.waitForSubs(reqId);
+    return resp.result as string;
+  }
+
+  async subscribeLogs(params: any) {
+    const reqId = this.id++;
+
+    this.ws.send(
+      this.buildRequest(reqId, ['logs', params])
+    );
+
+    const resp = await this.waitForSubs(reqId);
+    return resp.result as string;
+  }
+
+  async unSubscribe(subId: string) {
+    const reqId = this.id++;
+
+    this.ws.send(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: reqId,
+        method: 'eth_unsubscribe',
+        params: [subId],
+      })
+    );
+
+    const resp = await this.waitForSubs(reqId);
+    return resp.result as string;
+  }
+
+  close() {
+    this.ws.close();
+  }
+}
+
+export const getAddrSelector = (addr: string) => hexZeroPad(addr, 32);


### PR DESCRIPTION
## Change
refactored e2e tests so the logic is cleaner, and now it's compatible with both
- local network where tx confirms in next block, such as local mandala or chopsticks
- prod network where tx skips a block (which previously isn't compatible)

## Test
tested with both cases and worked 