### PR TITLE
estimateGas supports blocktag

### DIFF
--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -955,7 +955,7 @@ export abstract class BaseProvider extends AbstractProvider {
       ? this.api.tx.evm.call(...callParams)
       : this.api.tx.evm.create(...createParams);
 
-    let txFee = await this._estimateGasCost(extrinsic);
+    let txFee = await this._estimateGasCost(extrinsic, blockHash);
     txFee = txFee.mul(gasLimit).div(usedGas); // scale it to the same ratio when estimate passing gasLimit
 
     if (usedStorage.gt(0)) {

--- a/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -1940,6 +1940,9 @@ describe('endpoint', () => {
       const { gasLimit } = await estimateGas(tx);
       const bbb = (gasLimit.toNumber() % 100000) / 100;
 
+      const { gasLimit: gasLimitWithBlockTag } = await estimateGas(tx, 'latest');
+      expect(gasLimitWithBlockTag).to.equal(gasLimit);
+
       // should be passing gasLimit instead of usedGas
       expect(bbb).to.gt(GAS_MONSTER_GAS_REQUIRED / 30000);
 

--- a/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -1941,7 +1941,7 @@ describe('endpoint', () => {
       const bbb = (gasLimit.toNumber() % 100000) / 100;
 
       const { gasLimit: gasLimitWithBlockTag } = await estimateGas(tx, 'latest');
-      expect(gasLimitWithBlockTag).to.equal(gasLimit);
+      expect(gasLimitWithBlockTag.toBigInt()).to.equal(gasLimit.toBigInt());
 
       // should be passing gasLimit instead of usedGas
       expect(bbb).to.gt(GAS_MONSTER_GAS_REQUIRED / 30000);

--- a/packages/eth-rpc-adapter/src/__tests__/e2e/utils.ts
+++ b/packages/eth-rpc-adapter/src/__tests__/e2e/utils.ts
@@ -1,4 +1,5 @@
 import { BigNumber, ContractFactory, Signer } from 'ethers';
+import { BlockTagish } from '@acala-network/eth-providers';
 import { Log, TransactionRequest } from '@ethersproject/abstract-provider';
 import { expect } from 'vitest';
 import { hexValue } from '@ethersproject/bytes';
@@ -71,9 +72,9 @@ export const eth_getTransactionByHash_karura = rpcGet('eth_getTransactionByHash'
 export const eth_getBlockByNumber_karura = rpcGet('eth_getBlockByNumber', KARURA_ETH_RPC_URL);
 export const eth_getStorageAt_karura = rpcGet('eth_getStorageAt', KARURA_ETH_RPC_URL);
 
-export const estimateGas = async (tx: TransactionRequest) => {
+export const estimateGas = async (tx: TransactionRequest, blockTag?: BlockTagish) => {
   const gasPrice = (await eth_gasPrice([])).data.result;
-  const res = await eth_estimateGas([{ ...tx, gasPrice }]);
+  const res = await eth_estimateGas([{ ...tx, gasPrice }, blockTag]);
   if (res.data.error) {
     throw new Error(res.data.error.message);
   }

--- a/packages/eth-rpc-adapter/src/eip1193-bridge.ts
+++ b/packages/eth-rpc-adapter/src/eip1193-bridge.ts
@@ -293,8 +293,8 @@ class Eip1193BridgeImpl {
    * @returns GAS USED - the amount of gas used.
    */
   async eth_estimateGas(params: any[]): Promise<string> {
-    validate([{ type: 'transaction' }], params);
-    const val = await this.#provider.estimateGas(params[0]);
+    validate([{ type: 'transaction' }, { type: 'block?' }], params);
+    const val = await this.#provider.estimateGas(params[0], params[1]);
     return hexValue(val);
   }
 

--- a/packages/eth-rpc-adapter/src/validate.ts
+++ b/packages/eth-rpc-adapter/src/validate.ts
@@ -4,6 +4,7 @@ export type Schema = {
   type:
     | 'address'
     | 'block'
+    | 'block?'
     | 'transaction'
     | 'blockHash'
     | 'trasactionHash'
@@ -146,6 +147,10 @@ export const validate = (schema: Schema, data: unknown[]) => {
         }
         case 'block': {
           validateBlock(data[i]);
+          break;
+        }
+        case 'block?': {
+          data[i] && validateBlock(data[i]);
           break;
         }
         case 'transaction': {


### PR DESCRIPTION
## Change
`eth_estimateGas` now supports blocktag as second param

fix #854 
fix #891 

## Test
added tests to make sure passing "latest" returns same result as not passing blocktag