### PR TITLE
use latest for pending tag

### DIFF
--- a/packages/eth-providers/src/base-provider-dd.ts
+++ b/packages/eth-providers/src/base-provider-dd.ts
@@ -13,7 +13,6 @@ const TRACE_METHODS = [
   'getBalance',
   'getTransactionCount',
   'getEvmTransactionCount',
-  'getSubstrateNonce',
   'getCode',
   'call',
   '_ethCall',

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1506,6 +1506,7 @@ export abstract class BaseProvider extends AbstractProvider {
     const blockTag = _blockTag ?? 'latest';
 
     switch (blockTag) {
+      case 'pending':
       case 'latest': {
         return this.safeMode ? this.finalizedBlockHash : this.bestBlockHash;
       }

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -920,7 +920,7 @@ export abstract class BaseProvider extends AbstractProvider {
    */
   estimateGas = async (
     transaction: Deferrable<TransactionRequest>,
-    blockTag?: BlockTag | Promise<BlockTag>
+    blockTag?: BlockTag,
   ): Promise<BigNumber> => {
     const blockHash = blockTag && blockTag !== 'latest'
       ? await this._getBlockHash(blockTag)
@@ -1162,7 +1162,7 @@ export abstract class BaseProvider extends AbstractProvider {
     };
   };
 
-  getSubstrateAddress = async (addressOrName: string, blockTag?: BlockTag | Promise<BlockTag>): Promise<string> => {
+  getSubstrateAddress = async (addressOrName: string, blockTag?: BlockTag): Promise<string> => {
     const [address, blockHash] = await Promise.all([
       addressOrName,
       this._getBlockHash(blockTag),
@@ -1173,7 +1173,7 @@ export abstract class BaseProvider extends AbstractProvider {
     return substrateAccount.isEmpty ? computeDefaultSubstrateAddress(address) : substrateAccount.toString();
   };
 
-  getEvmAddress = async (substrateAddress: string, blockTag?: BlockTag | Promise<BlockTag>): Promise<string> => {
+  getEvmAddress = async (substrateAddress: string, blockTag?: BlockTag): Promise<string> => {
     const blockHash = await this._getBlockHash(blockTag);
     const evmAddress = await this.queryStorage<Option<H160>>('evmAccounts.evmAddresses', [substrateAddress], blockHash);
 
@@ -1474,11 +1474,8 @@ export abstract class BaseProvider extends AbstractProvider {
   };
 
   _getBlockNumber = async (blockTag: BlockTag): Promise<number> => {
-    if (blockTag === 'pending') {
-      blockTag = 'latest';
-    }
-
     switch (blockTag) {
+      case 'pending':
       case 'latest': {
         return this.getBlockNumber();
       }
@@ -1505,11 +1502,8 @@ export abstract class BaseProvider extends AbstractProvider {
     }
   };
 
-  _getBlockHash = async (_blockTag?: BlockTag | Promise<BlockTag>): Promise<string> => {
-    let blockTag = (await _blockTag) || 'latest';
-    if (blockTag === 'pending') {
-      blockTag = 'latest';
-    }
+  _getBlockHash = async (_blockTag?: BlockTag): Promise<string> => {
+    const blockTag = _blockTag ?? 'latest';
 
     switch (blockTag) {
       case 'latest': {
@@ -1612,7 +1606,7 @@ export abstract class BaseProvider extends AbstractProvider {
   };
 
   _getBlockHeader = async (blockTag?: BlockTag | Promise<BlockTag>): Promise<Header> => {
-    const blockHash = await this._getBlockHash(blockTag);
+    const blockHash = await this._getBlockHash(await blockTag);
 
     try {
       const header = await this.api.rpc.chain.getHeader(blockHash);


### PR DESCRIPTION
## Context
In ethers v6 it sends some RPC request with "pending" tag by default, so we should support pending tag and define it in a consistent way.

Previously we had 4 different behaviors for `pending` tag :joy:, some RPCs return empty, some throw error, some use `latest`, and some returns real pending state. 

## Change
We can directly use `latest` for `pending` tag, since with polkadot api alone, we can't calculate "future state" (except for pending nonce). go-eth [relies on the miner](https://github.com/ethereum/go-ethereum/blob/master/eth/api_backend.go#L190-L197) to provide the pending state, but polkadot api doesn't have access to that info. 

We might be able to gather pending extrinsics and do simulations on the execution result, but that is an overkill for now, since we don't have any app that relies heavily on pending state (probably not in the near future).

Note that it's not "wrong" to return result based on "latest" state, since "pending" state is indeterministic anyways, it relies on miner's discrepancy. So using "latest" is just like saying "this node has no determined tx in pending state yet".

In summary, new behavior:
- for getting account nonce with `pending` tag: returns true pending nonce (no change)
- for any other RPC request with `pending` tag: returns same result as `latest` tag

## Test
- added some tests to make sure `pending` returns same result as `latest`
- previous error `pending tag not supported` went away with latest hardhat + ethers v6 