### PR TITLE
decode eth gas params before estimate gas

### DIFF
--- a/examples/waffle/dex/test/Dex.test.ts
+++ b/examples/waffle/dex/test/Dex.test.ts
@@ -81,7 +81,6 @@ describe('Dex', () => {
     expect(
       await dex.swapWithExactSupply([ADDRESS.ACA, ADDRESS.AUSD], 1_000_000_000_000, 1, {
         value: ethers.utils.parseEther('1'),
-        gasLimit: 2_000_000
       })
     ).to.be.ok;
 
@@ -92,7 +91,6 @@ describe('Dex', () => {
     expect(
       await dex.swapWithExactSupply([ADDRESS.ACA, ADDRESS.AUSD, ADDRESS.DOT], 1_000_000_000_000, 1, {
         value: ethers.utils.parseEther('1'),
-        gasLimit: 2_000_000
       })
     ).to.be.ok;
     let pool_3 = await dex.getLiquidityPool(ADDRESS.ACA, ADDRESS.AUSD);
@@ -114,7 +112,6 @@ describe('Dex', () => {
     expect(
       await dex.swapWithExactTarget([ADDRESS.ACA, ADDRESS.AUSD], 1, 1_000_000_000_000, {
         value: ethers.utils.parseEther('1'),
-        gasLimit: 2_000_000
       })
     ).to.be.ok;
 
@@ -125,7 +122,6 @@ describe('Dex', () => {
     expect(
       await dex.swapWithExactTarget([ADDRESS.ACA, ADDRESS.AUSD, ADDRESS.DOT], 1, 1_000_000_000_000, {
         value: ethers.utils.parseEther('1'),
-        gasLimit: 2_000_000
       })
     ).to.be.ok;
     let pool_3 = await dex.getLiquidityPool(ADDRESS.AUSD, ADDRESS.DOT);
@@ -147,7 +143,6 @@ describe('Dex', () => {
     expect(
       await dex.swapWithExactTarget([ADDRESS.ACA, ADDRESS.AUSD], 1_000_000_000_000, 1_000_000_000_000, {
         value: ethers.utils.parseEther('1'),
-        gasLimit: 2_000_000
       })
     ).to.be.ok;
 
@@ -157,7 +152,6 @@ describe('Dex', () => {
     expect(
       await dex.addLiquidity(ADDRESS.ACA, ADDRESS.AUSD, 1_000_000_000_000, 1_000_000_000_000, 0, {
         value: ethers.utils.parseEther('1'),
-        gasLimit: 2_000_000
       })
     ).to.be.ok;
 
@@ -167,7 +161,6 @@ describe('Dex', () => {
     expect(
       await dex.removeLiquidity(ADDRESS.ACA, ADDRESS.AUSD, 100_000_000_000, 0, 0, {
         value: ethers.utils.parseEther('1'),
-        gasLimit: 2_000_000
       })
     ).to.be.ok;
   });

--- a/examples/waffle/erc20/test/LP-ACA-AUSD-Token.test.ts
+++ b/examples/waffle/erc20/test/LP-ACA-AUSD-Token.test.ts
@@ -24,9 +24,7 @@ describe('LP ACA-AUSD Token', () => {
 
     let pool_1 = await dex.getLiquidityPool(ADDRESS.ACA, ADDRESS.AUSD);
     expect(
-      await dex.addLiquidity(ADDRESS.ACA, ADDRESS.AUSD, 1_000_000_000_000, 1_000_000_000_000, 0, {
-        gasLimit: 2_000_000
-      })
+      await dex.addLiquidity(ADDRESS.ACA, ADDRESS.AUSD, 1_000_000_000_000, 1_000_000_000_000, 0)
     ).to.be.ok;
     let pool_2 = await dex.getLiquidityPool(ADDRESS.ACA, ADDRESS.AUSD);
     expect(pool_2[1].sub(pool_1[1])).to.equal(1_000_000_000_000);

--- a/examples/waffle/scheduler/test/Scheduler.test.ts
+++ b/examples/waffle/scheduler/test/Scheduler.test.ts
@@ -122,7 +122,6 @@ describe('Schedule', () => {
       wallet,
       RecurringPayment,
       [3, 4, ethers.utils.parseEther('1000'), transferTo],
-      { gasLimit: 2_000_000 }
     );
     // ACA as erc20 decimals is 12
     await erc20.transfer(recurringPayment.address, dollar.mul(5000));
@@ -178,7 +177,6 @@ describe('Schedule', () => {
 
     const subscription = await deployContract(wallet, Subscription, [subPrice, period], {
       value: ethers.utils.parseEther('5000'),
-      gasLimit: 2_000_000
     });
     if (!process.argv.includes('--with-ethereum-compatibility')) {
       // If it is not called by the maintainer, developer, or contract, it needs to be deployed first
@@ -192,7 +190,6 @@ describe('Schedule', () => {
     const subscriberContract = subscription.connect(subscriber as any);
     await subscriberContract.subscribe({
       value: ethers.utils.parseEther(formatAmount('10_000')).toString(),
-      gasLimit: 2_000_000
     });
 
     expect((await subscription.balanceOf(subscriberAddr)).toString()).to.equal(
@@ -225,7 +222,7 @@ describe('Schedule', () => {
     expect((await subscription.subTokensOf(subscriberAddr)).toString()).to.equal('6');
     expect((await subscription.monthsSubscribed(subscriberAddr)).toString()).to.equal('3');
 
-    await subscriberContract.unsubscribe({ gasLimit: 2_000_000 });
+    await subscriberContract.unsubscribe();
 
     current_block_number = await provider.getBlockNumber();
     await nextBlock(provider);

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1101,14 +1101,19 @@ export abstract class BaseProvider extends AbstractProvider {
 
     const minGasLimit = 21000;
 
-    // if user explicitly provides gasLimit, decode it and use as max value
-    const maxGasLimit = ethTx.gasLimit !== undefined
-      ? Number(substrateGasParams.gasLimit)
-      : BLOCK_GAS_LIMIT * 10;
-
-    const storageLimit = ethTx.gasLimit !== undefined
-      ? Number(substrateGasParams.storageLimit)
-      : BLOCK_STORAGE_LIMIT;
+    // if user explicitly provides gasLimit override, decode it and use as max values
+    // otherwise use default max values
+    const [
+      maxGasLimit,
+      storageLimit,
+    ] = ethTx.gasLimit !== undefined
+      ? [
+        Number(substrateGasParams.gasLimit),
+        Number(substrateGasParams.storageLimit),
+      ] : [
+        BLOCK_GAS_LIMIT * 10,
+        BLOCK_STORAGE_LIMIT,
+      ];
 
     const txRequest = {
       ...ethTx,

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1103,11 +1103,11 @@ export abstract class BaseProvider extends AbstractProvider {
 
     // if user explicitly provides gasLimit, decode it and use as max value
     const maxGasLimit = ethTx.gasLimit !== undefined
-      ? substrateGasParams.gasLimit
+      ? Number(substrateGasParams.gasLimit)
       : BLOCK_GAS_LIMIT * 10;
 
     const storageLimit = ethTx.gasLimit !== undefined
-      ? substrateGasParams.storageLimit
+      ? Number(substrateGasParams.storageLimit)
       : BLOCK_STORAGE_LIMIT;
 
     const txRequest = {

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1086,23 +1086,35 @@ export abstract class BaseProvider extends AbstractProvider {
    * @returns The estimated resources used by this transaction
    */
   estimateResources = async (
-    transaction: Deferrable<TransactionRequest>,
+    transaction: Deferrable<TxRequestWithGas>,
     blockHash?: string,
   ): Promise<{
     usedGas: BigNumber;
     gasLimit: BigNumber;
     usedStorage: BigNumber;
   }> => {
-    const MAX_GAS_LIMIT = BLOCK_GAS_LIMIT * 10; // capped at 10x (1000%) the current block gas limit
-    const MIN_GAS_LIMIT = 21000;
-    const STORAGE_LIMIT = BLOCK_STORAGE_LIMIT;
+    const ethTx = await getTransactionRequest(transaction);
+    const substrateGasParams = decodeEthGas({
+      gasLimit: ethTx.gasLimit ?? BigNumber.from(199999),   // use max storage limit and gas limit
+      gasPrice: ethTx.gasPrice ?? await this.getGasPrice(),
+    });
 
-    const _txRequest = await getTransactionRequest(transaction);
+    const minGasLimit = 21000;
+
+    // if user explicitly provides gasLimit, decode it and use as max value
+    const maxGasLimit = ethTx.gasLimit !== undefined
+      ? substrateGasParams.gasLimit
+      : BLOCK_GAS_LIMIT * 10;
+
+    const storageLimit = ethTx.gasLimit !== undefined
+      ? substrateGasParams.storageLimit
+      : BLOCK_STORAGE_LIMIT;
+
     const txRequest = {
-      ..._txRequest,
-      value: BigNumber.isBigNumber(_txRequest.value) ? _txRequest.value.toBigInt() : _txRequest.value,
-      gasLimit: _txRequest.gasLimit?.toBigInt() ?? MAX_GAS_LIMIT,
-      storageLimit: STORAGE_LIMIT,
+      ...ethTx,
+      ...substrateGasParams,
+      storageLimit,
+      value: BigNumber.isBigNumber(ethTx.value) ? ethTx.value.toBigInt() : ethTx.value,
     };
 
     const gasInfo = await this._ethCall(txRequest, blockHash);
@@ -1127,8 +1139,8 @@ export abstract class BaseProvider extends AbstractProvider {
 
     if (!gasAlreadyWorks) {
       // need to binary search the best passing gasLimit
-      let lowest = MIN_GAS_LIMIT;
-      let highest = MAX_GAS_LIMIT;
+      let lowest = minGasLimit;
+      let highest = maxGasLimit;
       let mid = Math.min(usedGas * 3, Math.floor((lowest + highest) / 2));
       let prevHighest = highest;
       while (highest - lowest > 1) {
@@ -1209,9 +1221,7 @@ export abstract class BaseProvider extends AbstractProvider {
     return accountInfo.unwrap().contractInfo;
   };
 
-  _getSubstrateGasParams = (
-    ethTx: Partial<AcalaEvmTX>
-  ): {
+  _getSubstrateGasParams = (ethTx: Partial<AcalaEvmTX>): {
     gasLimit: bigint;
     storageLimit: bigint;
     validUntil: bigint;

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1094,26 +1094,21 @@ export abstract class BaseProvider extends AbstractProvider {
     usedStorage: BigNumber;
   }> => {
     const ethTx = await getTransactionRequest(transaction);
-    const substrateGasParams = decodeEthGas({
-      gasLimit: ethTx.gasLimit ?? BigNumber.from(199999),   // use max storage limit and gas limit
-      gasPrice: ethTx.gasPrice ?? await this.getGasPrice(),
-    });
 
     const minGasLimit = 21000;
+    let maxGasLimit = BLOCK_GAS_LIMIT * 10;
+    let storageLimit = BLOCK_STORAGE_LIMIT;
 
     // if user explicitly provides gasLimit override, decode it and use as max values
-    // otherwise use default max values
-    const [
-      maxGasLimit,
-      storageLimit,
-    ] = ethTx.gasLimit !== undefined
-      ? [
-        Number(substrateGasParams.gasLimit),
-        Number(substrateGasParams.storageLimit),
-      ] : [
-        BLOCK_GAS_LIMIT * 10,
-        BLOCK_STORAGE_LIMIT,
-      ];
+    if (ethTx.gasLimit !== undefined) {
+      const substrateGasParams = decodeEthGas({
+        gasLimit: ethTx.gasLimit ?? BigNumber.from(199999),   // use max storage limit and gas limit
+        gasPrice: ethTx.gasPrice ?? await this.getGasPrice(),
+      });
+
+      maxGasLimit = Number(substrateGasParams.gasLimit);
+      storageLimit = Number(substrateGasParams.storageLimit);
+    }
 
     const txRequest = {
       ...ethTx,

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1117,7 +1117,7 @@ export abstract class BaseProvider extends AbstractProvider {
 
     const txRequest = {
       ...ethTx,
-      ...substrateGasParams,
+      gasLimit: maxGasLimit,
       storageLimit,
       value: BigNumber.isBigNumber(ethTx.value) ? ethTx.value.toBigInt() : ethTx.value,
     };

--- a/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -67,6 +67,7 @@ import {
   deployGasMonster,
   toDeterministic,
   waitForHeight,
+  eth_estimateGas,
 } from './utils';
 
 import {
@@ -2014,6 +2015,57 @@ describe('endpoint', () => {
       expect(bbb).to.gt(GAS_MONSTER_GAS_REQUIRED / 30000);
 
       await (await gm.run()).wait();    // make sure running has no error
+    });
+
+    describe('works with gas overrides', () => {
+      let token: Contract;
+
+      beforeAll(async () => {
+        token = await deployErc20(wallet);
+        await token.deployed();
+      });
+
+      it('works with valid gas overrides', async () => {
+        const tx = await token.populateTransaction.transfer(evmAccounts[1].evmAddress, 1000);
+        const { gasLimit: realGasLimit, gasPrice } = await estimateGas(tx);
+
+        const resps = await Promise.all([
+          eth_estimateGas([{ ...tx, gasPrice, gas: realGasLimit }]),
+          eth_estimateGas([{ ...tx, gasPrice }]),
+          eth_estimateGas([{ ...tx, gas: realGasLimit }]),
+
+          eth_estimateGas([{ ...tx, gas: 101520 }]),  // increase gas and storagelimits
+          eth_estimateGas([{ ...tx, gasPrice: parseUnits('234.001298752', 'gwei') }]),  // increase tip and valid until
+          eth_estimateGas([{ ...tx, gasPrice: parseUnits('321.001000000', 'gwei'), gas: 102518 }]),  // increase everything
+        ]);
+
+        const errs = resps.map(r => r.data.error);
+        if (errs.some(e => e !== undefined)) {
+          expect.fail(`some of the requests failed: ${JSON.stringify(errs, null, 2) }`);
+        }
+
+        const results = resps.map(r => r.data.result)
+          .slice(0, 4);   // last request has slightly different estimated gaslimit since it has different gasPrice
+        if (results.some(e => BigInt(e) !== realGasLimit.toBigInt())) {
+          expect.fail(`some of the requests returned wrong gasLimit: ${JSON.stringify(results, null, 2) }`);
+        }
+      });
+
+      it('throws error with invalid gas overrides', async () => {
+        const tx = await token.populateTransaction.transfer(Wallet.createRandom().address, 100000);
+
+        // gasPrice is ignored since evmRuntimeApi.call doesn't take tip and validUntil as params
+        const resps = await Promise.all([
+          eth_estimateGas([{ ...tx, gas: 201002 }]),  // too low storagelimit
+          eth_estimateGas([{ ...tx, gas: 200109 }]),  // too low gaslimit
+          eth_estimateGas([{ ...tx, gas: 200301 }]),  // too low gaslimit + storagelimit
+        ]);
+
+        const errs = resps.map(r => r.data.error);
+        if (errs.some(e => e === undefined)) {
+          expect.fail(`some of the requests didn't fail when it should: ${JSON.stringify(errs, null, 2) }`);
+        }
+      });
     });
   });
 });

--- a/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
+++ b/packages/eth-rpc-adapter/src/__tests__/e2e/endpoint.test.ts
@@ -2022,7 +2022,6 @@ describe('endpoint', () => {
 
       beforeAll(async () => {
         token = await deployErc20(wallet);
-        await token.deployed();
       });
 
       it('works with valid gas overrides', async () => {
@@ -2054,7 +2053,6 @@ describe('endpoint', () => {
       it('throws error with invalid gas overrides', async () => {
         const tx = await token.populateTransaction.transfer(Wallet.createRandom().address, 100000);
 
-        // gasPrice is ignored since evmRuntimeApi.call doesn't take tip and validUntil as params
         const resps = await Promise.all([
           eth_estimateGas([{ ...tx, gasPrice: parseUnits('100.000000001', 'gwei') }]),  // too low valid until
           eth_estimateGas([{ ...tx, gasPrice: parseUnits('38.0000090000', 'gwei') }]),  // invalid gasPrice

--- a/packages/eth-rpc-adapter/src/__tests__/e2e/utils.ts
+++ b/packages/eth-rpc-adapter/src/__tests__/e2e/utils.ts
@@ -72,7 +72,10 @@ export const eth_getTransactionByHash_karura = rpcGet('eth_getTransactionByHash'
 export const eth_getBlockByNumber_karura = rpcGet('eth_getBlockByNumber', KARURA_ETH_RPC_URL);
 export const eth_getStorageAt_karura = rpcGet('eth_getStorageAt', KARURA_ETH_RPC_URL);
 
-export const estimateGas = async (tx: TransactionRequest, blockTag?: BlockTagish) => {
+export const estimateGas = async (
+  tx: TransactionRequest,
+  blockTag?: BlockTagish
+) => {
   const gasPrice = (await eth_gasPrice([])).data.result;
   const res = await eth_estimateGas([{ ...tx, gasPrice }, blockTag]);
   if (res.data.error) {


### PR DESCRIPTION
## Change
Previously in `estimateGas` there were two issues in the corner case when there are gas overrides:
1) `gasPrice` params is ignored, and simply used default params
2) incorrectly use eth `gasLimit` as substrate `gasLimit`.

This commit fixes both of them by decoding eth gas overrides (if present), and use decoded gas/storage limit as the limit

## Test
added tests to make sure now `eth_estimateGas` takes gas overrides into consideration