### PR TITLE
call evm rpc when `state_call` is not supported yet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ services:
         condition: service_completed_successfully
     restart: always
     command:
-      - --endpoint=wss://acala-karura-eu-1.bdnodes.net:8443/parachain?auth=4VFR_UEvc8mUAd58z11nSRqp-EBZcqPl14j_MgEm-4E
+      - --endpoint=wss://karura-rpc.aca-api.network:8443
       - --subql=https://subql-query-karura.aca-api.network
       - --port=8546
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ services:
         condition: service_completed_successfully
     restart: always
     command:
-      - --endpoint=wss://karura-rpc.aca-api.network:8443
+      - --endpoint=wss://karura-rpc.aca-api.network
       - --subql=https://subql-query-karura.aca-api.network
       - --port=8546
 

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -820,9 +820,16 @@ export abstract class BaseProvider extends AbstractProvider {
     // call evm rpc when `state_call` is not supported yet
     if (!api.call.evmRuntimeRPCApi) {
       const data = await this.api.rpc.evm.call(callRequest);
-      return {
-        value: data.toHex(),
+      const res: CallInfo = {
+        ok: {
+          exit_reason: { succeed: 'Returned' },
+          value: data.toHex(),
+          used_gas: '0',
+          used_storage: 0,
+          logs: [],
+        },
       };
+      return res.ok;
     }
 
     const res = to

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -817,6 +817,14 @@ export abstract class BaseProvider extends AbstractProvider {
     const { from, to, gasLimit, storageLimit, value, data, accessList } = callRequest;
     const estimate = false;
 
+    // call evm rpc when `state_call` is not supported yet
+    if (!api.call.evmRuntimeRPCApi) {
+      const data = await this.api.rpc.evm.call(callRequest);
+      return {
+        value: data.toHex(),
+      };
+    }
+
     const res = to
       ? await api.call.evmRuntimeRPCApi.call(from, to, data, value, gasLimit, storageLimit, accessList, estimate)
       : await api.call.evmRuntimeRPCApi.create(from, data, value, gasLimit, storageLimit, accessList, estimate);


### PR DESCRIPTION
We need to support query of historical data, such as `balanceOf`
```
curl --location 'https://eth-rpc-acala-testnet.aca-staging.network' \
--header 'Content-Type: application/json' \
--data '{
    "id": 0,
    "jsonrpc": "2.0",
    "method": "eth_call",
    "params": [
        {
            "data": "0x70a0823100000000000000000000000012345756e90eba0c357d6ea5d537a179f9d6d0b0",
            "to": "0x0000000000000000000100000000000000000000"
        },
        "0x33382"
    ]
}'
```
```
{
    "id": 0,
    "jsonrpc": "2.0",
    "error": {
        "code": 6969,
        "message": "Error: Cannot read properties of undefined (reading 'call')"
    }
}
```