### PR TITLE
fix finalized height calculation when finalized is faster than best

### DIFF
--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -341,11 +341,18 @@ export abstract class BaseProvider extends AbstractProvider {
   }
 
   get finalizedBlockHash() {
-    return firstValueFrom(this.finalized$).then(({ hash }) => hash);
+    return firstValueFrom(this.finalized$).then(
+      ({ hash: chainFinalizedHash, number: chainFinalizedNumber }) =>
+        chainFinalizedNumber <= this.bestBlockNumber
+          ? chainFinalizedHash
+          : this.bestBlockHash
+    );
   }
 
   get finalizedBlockNumber() {
-    return firstValueFrom(this.finalized$).then(({ number }) => number);
+    return firstValueFrom(this.finalized$).then(
+      ({ number: chainFinalizedNumber }) => Math.min(this.bestBlockNumber, chainFinalizedNumber)
+    );
   }
 
   static isProvider(value: any): value is Provider {


### PR DESCRIPTION
## Change
if best height subscription is delayed, eth rpc might have delayed best state update, which is slower than chain finalized height. So we need to check and return the smaller of finalized height and the best height.
