### PR TITLE
add option to specify host for rpc server

### DIFF
--- a/packages/eth-rpc-adapter/src/index.ts
+++ b/packages/eth-rpc-adapter/src/index.ts
@@ -55,7 +55,8 @@ export async function start(): Promise<void> {
   version         : ${version}
   endpoint url    : ${opts.endpoint}
   subquery url    : ${opts.subqlUrl}
-  listening to    : ${opts.port}
+  server host     : ${opts.host}
+  server port     : ${opts.port}
   max blockCache  : ${opts.maxBlockCacheSize}
   max batchSize   : ${opts.maxBatchSize}  
   max storageSize : ${opts.storageCacheSize}

--- a/packages/eth-rpc-adapter/src/server.ts
+++ b/packages/eth-rpc-adapter/src/server.ts
@@ -10,6 +10,7 @@ import { errorHandler } from './middlewares';
 import { logger } from './utils/logger';
 
 export interface EthRpcServerOptions extends ServerOptions {
+  host?: string;
   port: number;
   batchSize: number;
   middleware?: HandleFunction[];
@@ -101,7 +102,7 @@ export default class EthRpcServer {
   }
 
   start(): void {
-    this.server.listen(this.options.port);
+    this.server.listen(this.options.port, this.options.host);
   }
 
   stop(): void {

--- a/packages/eth-rpc-adapter/src/utils/utils.ts
+++ b/packages/eth-rpc-adapter/src/utils/utils.ts
@@ -6,6 +6,7 @@ export const sleep = async (time = 1000): Promise<void> => new Promise(resolve =
 const {
   ENDPOINT_URL,
   SUBQL_URL,
+  HOST,
   PORT,
   MAX_CACHE_SIZE,
   MAX_BATCH_SIZE,
@@ -41,6 +42,13 @@ export const yargsOptions = yargs(hideBin(process.argv))
       default: SUBQL_URL,
       describe:
         'Subquery url: *optional* if testing contracts locally that doesn\'t query logs or historical Tx, otherwise *required*',
+      type: 'string',
+    },
+    host: {
+      alias: 'h',
+      demandOption: false,
+      default: HOST ?? 'localhost',
+      describe: 'host to listen for http and ws requests',
       type: 'string',
     },
     port: {


### PR DESCRIPTION
now can do `-h 0.0.0.0` to listen to 0.0.0.0 instead of localhost in some cases