### PR TITLE
get logs from cache

### DIFF
--- a/packages/eth-providers/src/__tests__/e2e/json-rpc-provider.test.ts
+++ b/packages/eth-providers/src/__tests__/e2e/json-rpc-provider.test.ts
@@ -174,6 +174,27 @@ describe('JsonRpcProvider', async () => {
     });
   });
 
+  describe('get logs without subql', () => {
+    it('works', async () => {
+      const echoFactory = new ContractFactory(echoJson.abi, echoJson.bytecode, wallet);
+      const echo = await echoFactory.deploy();
+
+      const { blockNumber: block0 } = await (await echo.scream('hello Gogeta!')).wait();
+      let logs = await wallet.provider.getLogs({
+        address: echo.address,
+      });
+      expect(logs.length).to.eq(1);
+
+      const { blockNumber: block1 } = await (await echo.scream('hello Vegito!')).wait();
+      logs = await wallet.provider.getLogs({
+        address: echo.address,
+        fromBlock: block0,
+        toBlock: block1,
+      });
+      expect(logs.length).to.eq(2);
+    });
+  });
+
   describe('subscription', () => {
     it('subscribe to new block', async () => {
       const curBlockNumber = await provider.getBlockNumber();

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1839,9 +1839,9 @@ export abstract class BaseProvider extends AbstractProvider {
       if (!earliestCachedBlockHash) return _throwErr();
 
       const earliestCachedBlockNumber = await this._getBlockNumber(earliestCachedBlockHash);
-      const isAllLogsIncache = earliestCachedBlockNumber <= filter.fromBlock;
+      const isAllTargetLogsInCache = earliestCachedBlockNumber <= filter.fromBlock;
 
-      return isAllLogsIncache
+      return isAllTargetLogsInCache
         ? this._getLogsFromCache(filter.fromBlock, filter.toBlock, filter)
         : _throwErr(earliestCachedBlockNumber);
     }

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1826,8 +1826,13 @@ export abstract class BaseProvider extends AbstractProvider {
     const filter = await this._sanitizeRawFilter(rawFilter);
 
     if (!this.subql) {
-      const _throwErr = () => logger.throwError(
-        'missing subql url to fetch logs, to initialize base provider with subql, please provide a subqlUrl param.'
+      const _throwErr = (earliestCachedBlockNumber?: number) => logger.throwError(
+        'cache does not contain enough info to fetch requested logs, please reduce block range or initialize provider with a subql url',
+        Logger.errors.SERVER_ERROR,
+        {
+          requestFromBlock: filter.fromBlock,
+          earliestCachedBlockNumber,
+        },
       );
 
       const earliestCachedBlockHash = this.blockCache.cachedBlockHashes[0];
@@ -1838,7 +1843,7 @@ export abstract class BaseProvider extends AbstractProvider {
 
       return isAllLogsIncache
         ? this._getLogsFromCache(filter.fromBlock, filter.toBlock, filter)
-        : _throwErr();
+        : _throwErr(earliestCachedBlockNumber);
     }
 
     // only filter by blockNumber and address, since topics are filtered at last

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1795,17 +1795,26 @@ export abstract class BaseProvider extends AbstractProvider {
   _getSubqlMissedLogs = async (toBlock: number, filter: SanitizedLogFilter): Promise<Log[]> => {
     const targetBlock = Math.min(toBlock, await this.finalizedBlockNumber);   // subql upperbound is finalizedBlockNumber
     const lastProcessedHeight = await this.subql.getLastProcessedHeight();
-    const missedBlockCount = targetBlock - lastProcessedHeight;
-    if (missedBlockCount <= 0) return [];
-
     const firstMissedHeight = lastProcessedHeight + 1;
-    const missedHeights = Array.from(
-      { length: missedBlockCount },
-      (_, i) => firstMissedHeight + i,
-    );
-    const missedBlockHashes = await Promise.all(missedHeights.map(this._getBlockHash.bind(this)));
 
-    return missedBlockHashes
+    return this._getLogsFromCache(firstMissedHeight, targetBlock, filter);
+  };
+
+  _getLogsFromCache = async (
+    fromBlock: number,
+    toBlock: number,
+    filter: SanitizedLogFilter,
+  ): Promise<Log[]> => {
+    const blockCount = toBlock - fromBlock + 1;   // when to === from, it should return 1 block
+    if (blockCount <= 0) return [];
+
+    const heights = Array.from(
+      { length: blockCount },
+      (_, i) => fromBlock + i,
+    );
+    const blockHashes = await Promise.all(heights.map(this._getBlockHash.bind(this)));
+
+    return blockHashes
       .map(this.blockCache.getLogsAtBlock.bind(this))
       .flat()
       .filter(log => filterLogByBlockNumber(log, filter.fromBlock, filter.toBlock))
@@ -1814,13 +1823,23 @@ export abstract class BaseProvider extends AbstractProvider {
 
   // Bloom-filter Queries
   getLogs = async (rawFilter: LogFilter): Promise<Log[]> => {
+    const filter = await this._sanitizeRawFilter(rawFilter);
+
     if (!this.subql) {
-      return logger.throwError(
+      const _throwErr = () => logger.throwError(
         'missing subql url to fetch logs, to initialize base provider with subql, please provide a subqlUrl param.'
       );
-    }
 
-    const filter = await this._sanitizeRawFilter(rawFilter);
+      const earliestCachedBlockHash = this.blockCache.cachedBlockHashes[0];
+      if (!earliestCachedBlockHash) return _throwErr();
+
+      const earliestCachedBlockNumber = await this._getBlockNumber(earliestCachedBlockHash);
+      const isAllLogsIncache = earliestCachedBlockNumber <= filter.fromBlock;
+
+      return isAllLogsIncache
+        ? this._getLogsFromCache(filter.fromBlock, filter.toBlock, filter)
+        : _throwErr();
+    }
 
     // only filter by blockNumber and address, since topics are filtered at last
     const [subqlLogs, extraLogs] = await Promise.all([


### PR DESCRIPTION
## Context
Currently when no subql is presented, we can't get logs at all. 

However, for most local testing scenarios, such as [chopsticks acala fork testnet](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fcrosschain-dev.polkawallet.io%3A9915#/explorer), it's deployed as a "light stack" without subql. In these cases we usually focus on recent txs/logs/blocks, and don't need to fetch very old data. So It would be nice if we can get (recent) logs without subql

## Change
If no subql, check if the cache contains all required blocks:
- if so fetch logs from the cache
- else throw error (should throw explicit error instead of returning false empty)

Now we can start eth rpc with big cache size to simulate a fully functional stack to test more conveniently

fix #901 

## Test
Added tests to make sure it can still getlogs without subql