### PR TITLE
use query storage helper

### DIFF
--- a/packages/eth-providers/src/__tests__/BlockCache.test.ts
+++ b/packages/eth-providers/src/__tests__/BlockCache.test.ts
@@ -2,7 +2,7 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider';
 
 import { BlockCache } from '../utils/BlockCache';
 import { describe, expect, it } from 'vitest';
-import { mockChain } from './utils/testUtils';
+import { mockChain } from './utils';
 
 const sortReceipt = (r1: TransactionReceipt, r2: TransactionReceipt) => {
   if (r1.blockNumber !== r2.blockNumber) {

--- a/packages/eth-providers/src/__tests__/MaxSizeSet.test.ts
+++ b/packages/eth-providers/src/__tests__/MaxSizeSet.test.ts
@@ -1,6 +1,7 @@
-import { MaxSizeSet } from '../utils/MaxSizeSet';
 import { describe, expect, it } from 'vitest';
-import { mockChain } from './utils/testUtils';
+
+import { MaxSizeSet } from '../utils/MaxSizeSet';
+import { mockChain } from './utils';
 
 describe('MaxSizeSet', () => {
   const MAX_CACHED_BLOCK = 5;

--- a/packages/eth-providers/src/__tests__/decimals.test.ts
+++ b/packages/eth-providers/src/__tests__/decimals.test.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { describe, expect, it } from 'vitest';
 import { hexValue } from '@ethersproject/bytes';
+
 import { nativeToEthDecimal } from '../utils';
 
 describe('decimals', () => {

--- a/packages/eth-providers/src/__tests__/dispatch-error-match.test.ts
+++ b/packages/eth-providers/src/__tests__/dispatch-error-match.test.ts
@@ -1,5 +1,6 @@
-import { ERROR_PATTERN } from '../consts';
 import { describe, expect, it } from 'vitest';
+
+import { ERROR_PATTERN } from '../consts';
 
 describe('filterLog', () => {
   const err0 =

--- a/packages/eth-providers/src/__tests__/evm-rpc-provider.test.ts
+++ b/packages/eth-providers/src/__tests__/evm-rpc-provider.test.ts
@@ -1,7 +1,8 @@
-import { EvmRpcProvider } from '../rpc-provider';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { runWithTiming, sleep } from '../utils';
 import dotenv from 'dotenv';
+
+import { EvmRpcProvider } from '../rpc-provider';
+import { sleep } from '../utils';
 
 dotenv.config();
 

--- a/packages/eth-providers/src/__tests__/getTransactionReceipt.test.ts
+++ b/packages/eth-providers/src/__tests__/getTransactionReceipt.test.ts
@@ -1,16 +1,15 @@
 import { Contract } from '@ethersproject/contracts';
 import { Wallet } from '@ethersproject/wallet';
 import { afterAll, describe, expect, it } from 'vitest';
+import { parseUnits } from 'ethers/lib/utils';
 import ACAABI from '@acala-network/contracts/build/contracts/Token.json';
 import ADDRESS from '@acala-network/contracts/utils/AcalaAddress';
 
 import { EvmRpcProvider } from '../rpc-provider';
-import { parseUnits } from 'ethers/lib/utils';
-import evmAccounts from './utils/evmAccounts';
+import { evmAccounts, nodeUrl } from './utils';
 
 describe('TransactionReceipt', async () => {
-  const endpoint = process.env.ENDPOINT_URL || 'ws://127.0.0.1:9944';
-  const provider = EvmRpcProvider.from(endpoint);
+  const provider = EvmRpcProvider.from(nodeUrl);
   await provider.isReady();
 
   afterAll(async () => {

--- a/packages/eth-providers/src/__tests__/json-rpc-provider.test.ts
+++ b/packages/eth-providers/src/__tests__/json-rpc-provider.test.ts
@@ -4,11 +4,9 @@ import { describe, expect, it } from 'vitest';
 import { hexZeroPad, parseEther } from 'ethers/lib/utils';
 
 import { AcalaJsonRpcProvider } from '../json-rpc-provider';
+import { ethRpc, evmAccounts } from './utils';
 import echoJson from './abis/Echo.json';
 import erc20Json from './abis/IERC20.json';
-import evmAccounts from './utils/evmAccounts';
-
-const localEthRpc = process.env.ETH_RPC || 'http://localhost:8545';
 
 describe('JsonRpcProvider', async () => {
   /* --------- karura --------- */
@@ -20,7 +18,7 @@ describe('JsonRpcProvider', async () => {
 
   /* --------- local --------- */
   const testKey = evmAccounts[0].privateKey;   // 0x75E480dB528101a381Ce68544611C169Ad7EB342
-  const providerLocal = new AcalaJsonRpcProvider(localEthRpc);
+  const providerLocal = new AcalaJsonRpcProvider(ethRpc);
   const wallet = new Wallet(testKey, providerLocal);
 
   describe.concurrent('get chain data', () => {

--- a/packages/eth-providers/src/__tests__/logs.test.ts
+++ b/packages/eth-providers/src/__tests__/logs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+
 import { filterLog } from '../utils';
 
 describe('filterLog', () => {

--- a/packages/eth-providers/src/__tests__/parseBlock.test.ts
+++ b/packages/eth-providers/src/__tests__/parseBlock.test.ts
@@ -3,8 +3,7 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import { options } from '@acala-network/api';
 
-import { getAllReceiptsAtBlock } from '../utils/parseBlock';
-import { hexlifyRpcResult, sleep } from '../utils';
+import { getAllReceiptsAtBlock, hexlifyRpcResult } from '../utils';
 
 interface FormatedReceipt {
   to?: string;

--- a/packages/eth-providers/src/__tests__/safemode.test.ts
+++ b/packages/eth-providers/src/__tests__/safemode.test.ts
@@ -1,11 +1,11 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EvmRpcProvider } from '../rpc-provider';
+import { nodeUrl } from './utils';
 import { sleep } from '../utils';
 
-const endpoint = process.env.ENDPOINT_URL || 'ws://127.0.0.1:9944';
-const safeProvider = EvmRpcProvider.from(endpoint, { safeMode: true });
-const provider = EvmRpcProvider.from(endpoint, { safeMode: false });
+const safeProvider = EvmRpcProvider.from(nodeUrl, { safeMode: true });
+const provider = EvmRpcProvider.from(nodeUrl, { safeMode: false });
 
 const newBlock = async (finalize: boolean): Promise<void> => {
   await provider.api.rpc.engine.createBlock(true /* create empty */, finalize);

--- a/packages/eth-providers/src/__tests__/tx.test.ts
+++ b/packages/eth-providers/src/__tests__/tx.test.ts
@@ -10,13 +10,11 @@ import ACAABI from '@acala-network/contracts/build/contracts/Token.json';
 import ADDRESS from '@acala-network/contracts/utils/MandalaAddress';
 
 import { EvmRpcProvider } from '../rpc-provider';
-import { calcEthereumTransactionParams } from '../utils';
-import { computeDefaultSubstrateAddress } from '../utils/address';
-import evmAccounts from './utils/evmAccounts';
+import { calcEthereumTransactionParams, computeDefaultSubstrateAddress } from '../utils';
+import { evmAccounts, nodeUrl } from './utils';
 
 describe('transaction tests', () => {
-  const endpoint = process.env.ENDPOINT_URL || 'ws://127.0.0.1:9944';
-  const provider = EvmRpcProvider.from(endpoint);
+  const provider = EvmRpcProvider.from(nodeUrl);
 
   const account1 = evmAccounts[0];
   const account2 = evmAccounts[1];

--- a/packages/eth-providers/src/__tests__/utils.test.ts
+++ b/packages/eth-providers/src/__tests__/utils.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { FrameSystemAccountInfo } from '@polkadot/types/lookup';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { hexValue } from '@ethersproject/bytes';
 
+import { ALICE_ADDR, nodeUrl } from './utils';
 import { CacheInspect } from '../utils/BlockCache';
 import {
   EthCallTimingResult,
@@ -13,8 +16,11 @@ import {
   runWithTiming,
   sleep,
 } from '../utils';
+import { EvmRpcProvider } from '../rpc-provider';
 import { HeadsInfo } from '../base-provider';
 import { _Metadata } from '../utils/gqlTypes';
+import { queryStorage } from '../utils/queryStoarge';
+
 
 describe('utils', () => {
   it('connect chain', async () => {
@@ -505,5 +511,70 @@ describe('eth call error handling', () => {
         expect(() => checkEvmExecutionError(data)).to.not.throw();
       }
     });
+  });
+});
+
+describe.only('query storage', () => {
+  let api: ApiPromise;
+
+
+  beforeAll(async () => {
+    api = await ApiPromise.create({ provider: new WsProvider(nodeUrl) });
+  });
+
+  afterAll(async () => {
+    await api.disconnect();
+  });
+
+  it.only('timestamp.now', async () => {
+    const _testQueryStorage = async (blockHash: string) => {
+      const timestamp = await queryStorage(
+        api,
+        'timestamp.now',
+        [],
+        blockHash
+      );
+
+      const timestampReal = await (await api.at(blockHash)).query.timestamp.now();
+
+      console.log(timestamp.toJSON(), timestampReal.toJSON());
+      expect(timestamp.toJSON()).to.deep.eq(timestampReal.toJSON());
+    };
+
+    const curBlockHash = (await api.rpc.chain.getBlockHash()).toString();
+    const curBlockNum = (await api.rpc.chain.getHeader()).number.toNumber();
+    const randBlock = curBlockNum - Math.floor(Math.random() * 1000);
+    console.log(curBlockNum, randBlock);
+    const randBlockHash = (await api.rpc.chain.getBlockHash(randBlock)).toString();
+
+    await _testQueryStorage(curBlockHash);
+    await _testQueryStorage(randBlockHash);
+  });
+
+  it('system.account', async () => {
+    const _testQueryStorage = async (blockHash: string) => {
+      const accountInfo = await queryStorage<FrameSystemAccountInfo>(
+        api,
+        'system.account',
+        [ALICE_ADDR],
+        blockHash
+      );
+
+      const accountInfoReal = await (await api.at(blockHash)).query.system.account(ALICE_ADDR);
+
+      console.log(accountInfo.toJSON(), accountInfoReal.toJSON());
+      expect(accountInfo.toJSON()).to.deep.eq(accountInfoReal.toJSON());
+    };
+
+    const curBlockHash = (await api.rpc.chain.getBlockHash()).toString();
+    const curBlockNum = (await api.rpc.chain.getHeader()).number.toNumber();
+    const randBlock = curBlockNum - Math.floor(Math.random() * 1000);
+    const randBlockHash = (await api.rpc.chain.getBlockHash(randBlock)).toString();
+
+    console.log(curBlockNum, randBlock);
+    console.log(curBlockHash, randBlockHash);
+
+    await _testQueryStorage(curBlockHash);
+    await _testQueryStorage(randBlockHash);   // fails on 7332027
   });
 });

--- a/packages/eth-providers/src/__tests__/utils.test.ts
+++ b/packages/eth-providers/src/__tests__/utils.test.ts
@@ -514,7 +514,7 @@ describe('eth call error handling', () => {
   });
 });
 
-describe.only('query storage', () => {
+describe('query storage', () => {
   let api: ApiPromise;
 
 
@@ -526,7 +526,7 @@ describe.only('query storage', () => {
     await api.disconnect();
   });
 
-  it.only('timestamp.now', async () => {
+  it('timestamp.now', async () => {
     const _testQueryStorage = async (blockHash: string) => {
       const timestamp = await queryStorage(
         api,

--- a/packages/eth-providers/src/__tests__/utils.test.ts
+++ b/packages/eth-providers/src/__tests__/utils.test.ts
@@ -551,7 +551,8 @@ describe('query storage', () => {
     await _testQueryStorage(randBlockHash);
   });
 
-  it('system.account', async () => {
+  // FIXME: improve query storage helper to return consistent results as apiAt.query
+  it.skip('system.account', async () => {
     const _testQueryStorage = async (blockHash: string) => {
       const accountInfo = await queryStorage<FrameSystemAccountInfo>(
         api,

--- a/packages/eth-providers/src/__tests__/utils/evmAccounts.ts
+++ b/packages/eth-providers/src/__tests__/utils/evmAccounts.ts
@@ -1,4 +1,4 @@
-export default [
+export const evmAccounts = [
   {
     privateKey: '0xa872f6cbd25a0e04a08b1e21098017a9e6194d101d75e13111f71410c59cd57f',
     evmAddress: '0x75E480dB528101a381Ce68544611C169Ad7EB342',

--- a/packages/eth-providers/src/__tests__/utils/index.ts
+++ b/packages/eth-providers/src/__tests__/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './testUtils';
+export * from './evmAccounts';

--- a/packages/eth-providers/src/__tests__/utils/testUtils.ts
+++ b/packages/eth-providers/src/__tests__/utils/testUtils.ts
@@ -1,5 +1,10 @@
 import { TransactionReceipt } from '@ethersproject/abstract-provider';
 
+export const nodeUrl = process.env.ENDPOINT_URL || 'ws://localhost:9944';
+export const ethRpc = process.env.ETH_RPC || 'http://localhost:8545';
+
+export const ALICE_ADDR = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+
 type MochBlock = {
   blockHash: string;
   blockNumber: number;

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -1138,7 +1138,7 @@ export abstract class BaseProvider extends AbstractProvider {
     const blockHash = await this._getBlockHash(blockTag);
     const substrateAccount = await queryStorage<Option<AccountId32>>(
       this.api,
-      'evm.accounts',
+      'evmAccounts.accounts',
       [address],
       blockHash
     );

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -955,7 +955,7 @@ export abstract class BaseProvider extends AbstractProvider {
     extrinsic: SubmittableExtrinsic<'promise', ISubmittableResult>,
     at?: string,
   ) => {
-    const blockHash = at ?? await this._getBlockHash('latest');
+    const blockHash = at ?? this.bestBlockHash;
     const apiAt = await apiCache.getApiAt(this.api, blockHash);
 
     const u8a = extrinsic.toU8a();

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -14,18 +14,19 @@ import {
 } from '@ethersproject/abstract-provider';
 import { AcalaEvmTX, checkSignatureType, parseTransaction } from '@acala-network/eth-transactions';
 import { AccessList, accessListify } from 'ethers/lib/utils';
+import { AccountId32, H160, H256, Header } from '@polkadot/types/interfaces';
 import { ApiPromise } from '@polkadot/api';
 import { AsyncAction } from 'rxjs/internal/scheduler/AsyncAction';
 import { AsyncScheduler } from 'rxjs/internal/scheduler/AsyncScheduler';
 import { BigNumber, BigNumberish, Wallet } from 'ethers';
 import { Deferrable, defineReadOnly, resolveProperties } from '@ethersproject/properties';
 import { Formatter } from '@ethersproject/providers';
-import { Header } from '@polkadot/types/interfaces';
+import { FrameSystemAccountInfo, ModuleEvmModuleAccountInfo } from '@polkadot/types/lookup';
 import { ISubmittableResult } from '@polkadot/types/types';
 import { Logger } from '@ethersproject/logger';
-import { ModuleEvmModuleAccountInfo } from '@polkadot/types/lookup';
 import { Network } from '@ethersproject/networks';
 import { Observable, ReplaySubject, Subscription, firstValueFrom, throwError } from 'rxjs';
+import { Option, u64 } from '@polkadot/types-codec';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { filter, first, timeout } from 'rxjs/operators';
 import { getAddress } from '@ethersproject/address';
@@ -93,6 +94,7 @@ import { MaxSizeSet } from './utils/MaxSizeSet';
 import { SubqlProvider } from './utils/subqlProvider';
 import { _Metadata } from './utils/gqlTypes';
 import { apiCache } from './utils/ApiAtCache';
+import { queryStorage } from './utils/queryStoarge';
 
 export interface HeadsInfo {
   internalState: {
@@ -596,8 +598,7 @@ export abstract class BaseProvider extends AbstractProvider {
   );
 
   getTimestamp = async (blockHash: string): Promise<number> => {
-    const apiAt = await apiCache.getApiAt(this.api, blockHash);
-    const timestamp = await apiAt.query.timestamp.now();
+    const timestamp = await queryStorage<u64>(this.api, 'timestamp.now', [], blockHash);
     return timestamp.toNumber();
   };
 
@@ -704,8 +705,12 @@ export abstract class BaseProvider extends AbstractProvider {
 
     const substrateAddress = await this.getSubstrateAddress(address, blockHash);
 
-    const apiAt = await apiCache.getApiAt(this.api, blockHash);
-    const accountInfo = await apiAt.query.system.account(substrateAddress);
+    const accountInfo = await queryStorage<FrameSystemAccountInfo>(
+      this.api,
+      'system.account',
+      [substrateAddress],
+      blockHash
+    );
 
     return nativeToEthDecimal(accountInfo.data.free.toBigInt());
   };
@@ -746,9 +751,7 @@ export abstract class BaseProvider extends AbstractProvider {
     const contractInfo = evmAccountInfo?.contractInfo.unwrapOr(null);
     if (!contractInfo) { return '0x'; }
 
-    const apiAt = await apiCache.getApiAt(this.api, blockHash);
-    const code = await apiAt.query.evm.codes(contractInfo.codeHash);
-
+    const code = await queryStorage(this.api, 'evm.codes', [contractInfo.codeHash], blockHash);
     return code.toHex();
   };
 
@@ -844,8 +847,12 @@ export abstract class BaseProvider extends AbstractProvider {
       Promise.resolve(position).then(hexValue),
     ]);
 
-    const apiAt = await apiCache.getApiAt(this.api, blockHash);
-    const code = await apiAt.query.evm.accountStorages(address, hexZeroPad(resolvedPosition, 32));
+    const code = await queryStorage<H256>(
+      this.api,
+      'evm.accountStorages',
+      [address, hexZeroPad(resolvedPosition, 32)],
+      blockHash
+    );
 
     return code.toHex();
   };
@@ -948,7 +955,8 @@ export abstract class BaseProvider extends AbstractProvider {
     extrinsic: SubmittableExtrinsic<'promise', ISubmittableResult>,
     at?: string,
   ) => {
-    const apiAt = await apiCache.getApiAt(this.api, at ?? await this.bestBlockHash);
+    const blockHash = at ?? await this._getBlockHash('latest');
+    const apiAt = await apiCache.getApiAt(this.api, blockHash);
 
     const u8a = extrinsic.toU8a();
     const lenIncreaseAfterSignature = 100;    // approximate length increase after signature
@@ -1128,8 +1136,12 @@ export abstract class BaseProvider extends AbstractProvider {
 
   getSubstrateAddress = async (address: string, blockTag?: BlockTag): Promise<string> => {
     const blockHash = await this._getBlockHash(blockTag);
-    const apiAt = await apiCache.getApiAt(this.api, blockHash);
-    const substrateAccount = await apiAt.query.evmAccounts.accounts(address);
+    const substrateAccount = await queryStorage<Option<AccountId32>>(
+      this.api,
+      'evm.accounts',
+      [address],
+      blockHash
+    );
 
     return substrateAccount.isEmpty
       ? computeDefaultSubstrateAddress(address)
@@ -1138,8 +1150,12 @@ export abstract class BaseProvider extends AbstractProvider {
 
   getEvmAddress = async (substrateAddress: string, blockTag?: BlockTag): Promise<string> => {
     const blockHash = await this._getBlockHash(blockTag);
-    const apiAt = await apiCache.getApiAt(this.api, blockHash);
-    const evmAddress = await apiAt.query.evmAccounts.evmAddresses(substrateAddress);
+    const evmAddress = await queryStorage<Option<H160>>(
+      this.api,
+      'evmAccounts.evmAddresses',
+      [substrateAddress],
+      blockHash
+    );
 
     return getAddress(evmAddress.isEmpty ? computeDefaultEvmAddress(substrateAddress) : evmAddress.toString());
   };
@@ -1155,8 +1171,12 @@ export abstract class BaseProvider extends AbstractProvider {
       this._getBlockHash(blockTag),
     ]);
 
-    const apiAt = await apiCache.getApiAt(this.api, blockHash);
-    const accountInfo = await apiAt.query.evm.accounts(address);
+    const accountInfo = await queryStorage<Option<ModuleEvmModuleAccountInfo>>(
+      this.api,
+      'evm.accounts',
+      [address],
+      blockHash
+    );
 
     return accountInfo.unwrapOr(null);
   };

--- a/packages/eth-providers/src/utils/parseBlock.ts
+++ b/packages/eth-providers/src/utils/parseBlock.ts
@@ -13,6 +13,7 @@ import {
 import { FrameSystemEventRecord } from '@polkadot/types/lookup';
 import { GenericExtrinsic } from '@polkadot/types';
 import { TransactionReceipt } from '@ethersproject/abstract-provider';
+import { Vec } from '@polkadot/types-codec';
 
 import { BIGNUMBER_ZERO, ONE_HUNDRED_GWEI } from '../consts';
 import { apiCache } from './ApiAtCache';
@@ -32,17 +33,16 @@ import {
   isTxFeeEvent,
   nativeToEthDecimal,
 } from './utils';
+import { queryStorage } from './queryStoarge';
 
 export const getAllReceiptsAtBlock = async (
   api: ApiPromise,
   blockHash: string,
   targetTxHash?: string
 ): Promise<TransactionReceipt[]> => {
-  const apiAt = await apiCache.getApiAt(api, blockHash);
-
   const [block, blockEvents] = await Promise.all([
     api.rpc.chain.getBlock(blockHash),
-    apiAt.query.system.events(),
+    queryStorage<Vec<FrameSystemEventRecord>>(api, 'system.events', [], blockHash),
   ]);
 
   return await parseReceiptsFromBlockData(api, block, blockEvents, targetTxHash, true);

--- a/packages/eth-providers/src/utils/queryStoarge.ts
+++ b/packages/eth-providers/src/utils/queryStoarge.ts
@@ -1,7 +1,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { Codec } from '@polkadot/types/types';
 import { decorateStorage, unwrapStorageType } from '@polkadot/types';
-import { isNull, u8aToU8a } from '@polkadot/util';
+import { u8aToU8a } from '@polkadot/util';
 
 export const queryStorage = async <T extends Codec = Codec>(
   api: ApiPromise,
@@ -9,57 +9,45 @@ export const queryStorage = async <T extends Codec = Codec>(
   args: any[],
   blockHash: string,
 ): Promise<T> => {
-  const apiAt = await api.at(blockHash);
+  const registry = await api.getBlockRegistry(u8aToU8a(blockHash));
+
+  const storage = decorateStorage(
+    registry.registry,
+    registry.metadata.asLatest,
+    registry.metadata.version,
+  );
+
   const [section, method] = module.split('.');
-  const res = await apiAt.query[section][method](...args);
-  return res as T;
+
+  const entry = storage[section][method];
+  const key = entry(...args);
+
+  const outputType = unwrapStorageType(
+    registry.registry,
+    entry.meta.type,
+    entry.meta.modifier.isOptional,
+  );
+
+
+  const value: any = await api.rpc.state.getStorage(key, blockHash);
+
+  // we convert to Uint8Array since it maps to the raw encoding, all
+  // data will be correctly encoded (incl. numbers, excl. :code)
+  const input = value === null
+    ? null
+    : u8aToU8a(
+      entry.meta.modifier.isOptional
+        ? value.toU8a()
+        : value.isSome
+          ? value.unwrap().toU8a()
+          : null,
+    );
+
+
+  const result = registry.registry.createTypeUnsafe<T>(outputType, [input], {
+    blockHash,
+    isPedantic: !entry.meta.modifier.isOptional,
+  });
+
+  return result;
 };
-
-// export const queryStorage = async <T extends Codec = Codec>(
-//   api: ApiPromise,
-//   module: `${string}.${string}`,
-//   args: any[],
-//   blockHash: string,
-// ): Promise<T> => {
-//   const registry = await api.getBlockRegistry(u8aToU8a(blockHash));
-
-//   const storage = decorateStorage(
-//     registry.registry,
-//     registry.metadata.asLatest,
-//     registry.metadata.version,
-//   );
-
-//   const [section, method] = module.split('.');
-
-//   const entry = storage[section][method];
-//   const key = entry(...args);
-
-//   const outputType = unwrapStorageType(
-//     registry.registry,
-//     entry.meta.type,
-//     entry.meta.modifier.isOptional,
-//   );
-
-
-//   const value: any = await api.rpc.state.getStorage(key, blockHash);
-
-//   // we convert to Uint8Array since it maps to the raw encoding, all
-//   // data will be correctly encoded (incl. numbers, excl. :code)
-//   const input = value === null
-//     ? null
-//     : u8aToU8a(
-//       entry.meta.modifier.isOptional
-//         ? value.toU8a()
-//         : value.isSome
-//           ? value.unwrap().toU8a()
-//           : null,
-//     );
-
-
-//   const result = registry.registry.createTypeUnsafe<T>(outputType, [input], {
-//     blockHash,
-//     isPedantic: !entry.meta.modifier.isOptional,
-//   });
-
-//   return result;
-// };

--- a/packages/eth-providers/src/utils/queryStoarge.ts
+++ b/packages/eth-providers/src/utils/queryStoarge.ts
@@ -1,7 +1,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { Codec } from '@polkadot/types/types';
 import { decorateStorage, unwrapStorageType } from '@polkadot/types';
-import { u8aToU8a } from '@polkadot/util';
+import { isNull, u8aToU8a } from '@polkadot/util';
 
 export const queryStorage = async <T extends Codec = Codec>(
   api: ApiPromise,
@@ -9,45 +9,57 @@ export const queryStorage = async <T extends Codec = Codec>(
   args: any[],
   blockHash: string,
 ): Promise<T> => {
-  const registry = await api.getBlockRegistry(u8aToU8a(blockHash));
-
-  const storage = decorateStorage(
-    registry.registry,
-    registry.metadata.asLatest,
-    registry.metadata.version,
-  );
-
+  const apiAt = await api.at(blockHash);
   const [section, method] = module.split('.');
-
-  const entry = storage[section][method];
-  const key = entry(...args);
-
-  const outputType = unwrapStorageType(
-    registry.registry,
-    entry.meta.type,
-    entry.meta.modifier.isOptional,
-  );
-
-
-  const value: any = await api.rpc.state.getStorage(key, blockHash);
-
-  // we convert to Uint8Array since it maps to the raw encoding, all
-  // data will be correctly encoded (incl. numbers, excl. :code)
-  const input = value === null
-    ? null
-    : u8aToU8a(
-      entry.meta.modifier.isOptional
-        ? value.toU8a()
-        : value.isSome
-          ? value.unwrap().toU8a()
-          : null,
-    );
-
-
-  const result = registry.registry.createTypeUnsafe<T>(outputType, [input], {
-    blockHash,
-    isPedantic: !entry.meta.modifier.isOptional,
-  });
-
-  return result;
+  const res = await apiAt.query[section][method](...args);
+  return res as T;
 };
+
+// export const queryStorage = async <T extends Codec = Codec>(
+//   api: ApiPromise,
+//   module: `${string}.${string}`,
+//   args: any[],
+//   blockHash: string,
+// ): Promise<T> => {
+//   const registry = await api.getBlockRegistry(u8aToU8a(blockHash));
+
+//   const storage = decorateStorage(
+//     registry.registry,
+//     registry.metadata.asLatest,
+//     registry.metadata.version,
+//   );
+
+//   const [section, method] = module.split('.');
+
+//   const entry = storage[section][method];
+//   const key = entry(...args);
+
+//   const outputType = unwrapStorageType(
+//     registry.registry,
+//     entry.meta.type,
+//     entry.meta.modifier.isOptional,
+//   );
+
+
+//   const value: any = await api.rpc.state.getStorage(key, blockHash);
+
+//   // we convert to Uint8Array since it maps to the raw encoding, all
+//   // data will be correctly encoded (incl. numbers, excl. :code)
+//   const input = value === null
+//     ? null
+//     : u8aToU8a(
+//       entry.meta.modifier.isOptional
+//         ? value.toU8a()
+//         : value.isSome
+//           ? value.unwrap().toU8a()
+//           : null,
+//     );
+
+
+//   const result = registry.registry.createTypeUnsafe<T>(outputType, [input], {
+//     blockHash,
+//     isPedantic: !entry.meta.modifier.isOptional,
+//   });
+
+//   return result;
+// };

--- a/packages/eth-providers/src/utils/queryStoarge.ts
+++ b/packages/eth-providers/src/utils/queryStoarge.ts
@@ -1,0 +1,53 @@
+import { ApiPromise } from '@polkadot/api';
+import { Codec } from '@polkadot/types/types';
+import { decorateStorage, unwrapStorageType } from '@polkadot/types';
+import { u8aToU8a } from '@polkadot/util';
+
+export const queryStorage = async <T extends Codec = Codec>(
+  api: ApiPromise,
+  module: `${string}.${string}`,
+  args: any[],
+  blockHash: string,
+): Promise<T> => {
+  const registry = await api.getBlockRegistry(u8aToU8a(blockHash));
+
+  const storage = decorateStorage(
+    registry.registry,
+    registry.metadata.asLatest,
+    registry.metadata.version,
+  );
+
+  const [section, method] = module.split('.');
+
+  const entry = storage[section][method];
+  const key = entry(...args);
+
+  const outputType = unwrapStorageType(
+    registry.registry,
+    entry.meta.type,
+    entry.meta.modifier.isOptional,
+  );
+
+
+  const value: any = await api.rpc.state.getStorage(key, blockHash);
+
+  // we convert to Uint8Array since it maps to the raw encoding, all
+  // data will be correctly encoded (incl. numbers, excl. :code)
+  const input = value === null
+    ? null
+    : u8aToU8a(
+      entry.meta.modifier.isOptional
+        ? value.toU8a()
+        : value.isSome
+          ? value.unwrap().toU8a()
+          : null,
+    );
+
+
+  const result = registry.registry.createTypeUnsafe<T>(outputType, [input], {
+    blockHash,
+    isPedantic: !entry.meta.modifier.isOptional,
+  });
+
+  return result;
+};


### PR DESCRIPTION
## Change
Using api to query storage still has the memory issue https://github.com/polkadot-js/api/issues/5981, so we switch back to the original query storage helper, but removed all cache for storage query. This is because there was a bug in the cache, and as we mentioned in #1039, caching storage won't be too useful.

We still keep the `blockHash => { blockNumber, Header, BlockData }` cache introduced in #1039 , which are commonly used. We keep the apiAt cache as well, which can speed up runtime calls.

fix #1059 

Although there is a small inconsistency when querying `system.account` compared to `apiAt.query`, it does not affect our use case (we have been using this for a long time anyways). But in the future it would be nice to make it better, maybe @ntduan can take a look at #1060 when you got a chance?

## Test
all tests still pass (except the skipped one for storage query helper)