### PR TITLE
add option for cache capacity

### DIFF
--- a/packages/eth-providers/src/rpc-provider.ts
+++ b/packages/eth-providers/src/rpc-provider.ts
@@ -1,20 +1,26 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { withAcalaTypes } from '@acala-network/api';
+import { acalaTypesBundle } from '@acala-network/types';
 
 import { BaseProvider, BaseProviderOptions } from './base-provider';
 
+export type EvmRpcProviderOptions = BaseProviderOptions & {
+  rpcCacheCapacity?: number;
+};
+
 export class EvmRpcProvider extends BaseProvider {
-  constructor(endpoint: string | string[], opts?: BaseProviderOptions) {
+  constructor(endpoint: string | string[], opts?: EvmRpcProviderOptions) {
     super(opts);
 
-    const api = new ApiPromise(withAcalaTypes({
+    const api = new ApiPromise({
       provider: new WsProvider(endpoint),
-    }));
+      typesBundle: acalaTypesBundle,
+      rpcCacheCapacity: opts?.rpcCacheCapacity,
+    });
 
     this.setApi(api);
   }
 
-  static from(endpoint: string | string[], opt?: BaseProviderOptions): EvmRpcProvider {
+  static from(endpoint: string | string[], opt?: EvmRpcProviderOptions): EvmRpcProvider {
     return new EvmRpcProvider(endpoint, opt);
   }
 }

--- a/packages/eth-rpc-adapter/src/index.ts
+++ b/packages/eth-rpc-adapter/src/index.ts
@@ -18,6 +18,7 @@ export async function start(): Promise<void> {
     subqlUrl: opts.subqlUrl,
     maxBlockCacheSize: opts.maxBlockCacheSize,
     storageCacheSize: opts.storageCacheSize,
+    rpcCacheCapacity: opts.rpcCacheCapacity,
   });
 
   const bridge = new Eip1193Bridge(provider);
@@ -58,8 +59,9 @@ export async function start(): Promise<void> {
   server host     : ${opts.host}
   server port     : ${opts.port}
   max blockCache  : ${opts.maxBlockCacheSize}
-  max batchSize   : ${opts.maxBatchSize}  
+  max batchSize   : ${opts.maxBatchSize}
   max storageSize : ${opts.storageCacheSize}
+  cache capacity  : ${opts.rpcCacheCapacity}
   safe mode       : ${opts.safeMode}
   local mode      : ${opts.localMode}
   http only       : ${opts.httpOnly}

--- a/packages/eth-rpc-adapter/src/utils/utils.ts
+++ b/packages/eth-rpc-adapter/src/utils/utils.ts
@@ -11,6 +11,7 @@ const {
   MAX_CACHE_SIZE,
   MAX_BATCH_SIZE,
   STORAGE_CACHE_SIZE,
+  RPC_CACHE_CAPACITY,
   SAFE_MODE,
   LOCAL_MODE,
   HTTP_ONLY,
@@ -74,6 +75,12 @@ export const yargsOptions = yargs(hideBin(process.argv))
       demandOption: false,
       default: Number(STORAGE_CACHE_SIZE ?? 5000),
       describe: 'max storage cache size',
+      type: 'number',
+    },
+    rpcCacheCapacity: {
+      demandOption: false,
+      default: Number(RPC_CACHE_CAPACITY ?? 1000),
+      describe: 'polkadot api rpc cache capacity',
       type: 'number',
     },
     safeMode: {

--- a/packages/eth-rpc-adapter/src/wrapped-provider.ts
+++ b/packages/eth-rpc-adapter/src/wrapped-provider.ts
@@ -1,6 +1,7 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { BaseProvider, BaseProviderOptions } from '@acala-network/eth-providers/base-provider';
-import { withAcalaTypes } from '@acala-network/api';
+import { BaseProvider } from '@acala-network/eth-providers/base-provider';
+import { EvmRpcProviderOptions } from '@acala-network/eth-providers';
+import { acalaTypesBundle } from '@acala-network/types';
 import tracer from 'dd-trace';
 
 const TRACE_METHODS = [
@@ -78,17 +79,19 @@ export class BaseProviderWithTrace extends BaseProvider {
 }
 
 export class EvmRpcProviderWithTrace extends BaseProviderWithTrace {
-  constructor(endpoint: string | string[], opts?: BaseProviderOptions) {
+  constructor(endpoint: string | string[], opts?: EvmRpcProviderOptions) {
     super(opts);
 
-    const api = new ApiPromise(withAcalaTypes({
+    const api = new ApiPromise({
       provider: new WsProvider(endpoint),
-    }));
+      typesBundle: acalaTypesBundle,
+      rpcCacheCapacity: opts?.rpcCacheCapacity,
+    });
 
     this.setApi(api);
   }
 
-  static from(endpoint: string | string[], opt?: BaseProviderOptions): EvmRpcProviderWithTrace {
+  static from(endpoint: string | string[], opt?: EvmRpcProviderOptions): EvmRpcProviderWithTrace {
     return new EvmRpcProviderWithTrace(endpoint, opt);
   }
 }


### PR DESCRIPTION
## Change
latest pjs adds a config to control it's cache size, so let's give it one more chance. 

hopefully fix #1050 

In general I still think we should avoid building low level stuff ourselves (if possible), since it's very hard to make sure it works **precisely**. By adding 2 simple tests, we can already found the storage query we have been using for a long time actually [returns wrong result](https://github.com/AcalaNetwork/bodhi.js/pull/1051/files#diff-4a3dc323eef5011944040c4e54f390799ad09950ff9bf2174a85e82617723c78R566), just happened to not affect our use case (as far as we know). 

## Test
all tests still pass