### PR TITLE
fix eth_call with gasLimit

### DIFF
--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -772,6 +772,7 @@ export abstract class BaseProvider extends AbstractProvider {
     const callRequest: SubstrateEvmCallRequest = {
       ...ethReq,
       value: ethReq.value?.toBigInt(),
+      gasPrice: ethReq.gasPrice?.toBigInt(),
       gasLimit: ethReq.gasLimit?.toBigInt(),
     };
 

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -766,14 +766,26 @@ export abstract class BaseProvider extends AbstractProvider {
       this._getBlockHash(blockTag),
     ]);
 
-    ethReq.gasPrice ??= await this.getGasPrice();
-    ethReq.gasLimit ??= BigNumber.from(999999920);
+    let gasLimit;
+    let storageLimit;
+
+    if (!ethReq.gasLimit) {
+      ethReq.gasPrice ??= await this.getGasPrice();
+      ethReq.gasLimit ??= BigNumber.from(999999920);
+
+      const substrateGas = this._getSubstrateGasParams(ethReq);
+      gasLimit = substrateGas.gasLimit;
+      storageLimit = substrateGas.storageLimit;
+    } else {
+      gasLimit = ethReq.gasLimit?.toBigInt();
+      storageLimit = BLOCK_STORAGE_LIMIT;
+    }
 
     const callRequest: SubstrateEvmCallRequest = {
       ...ethReq,
       value: ethReq.value?.toBigInt(),
-      gasPrice: ethReq.gasPrice?.toBigInt(),
-      gasLimit: ethReq.gasLimit?.toBigInt(),
+      gasLimit,
+      storageLimit
     };
 
     const res = await this._ethCall(callRequest, blockHash);

--- a/packages/eth-providers/src/base-provider.ts
+++ b/packages/eth-providers/src/base-provider.ts
@@ -769,12 +769,10 @@ export abstract class BaseProvider extends AbstractProvider {
     ethReq.gasPrice ??= await this.getGasPrice();
     ethReq.gasLimit ??= BigNumber.from(999999920);
 
-    const substrateGas = this._getSubstrateGasParams(ethReq);
-
     const callRequest: SubstrateEvmCallRequest = {
       ...ethReq,
       value: ethReq.value?.toBigInt(),
-      ...substrateGas,
+      gasLimit: ethReq.gasLimit?.toBigInt(),
     };
 
     const res = await this._ethCall(callRequest, blockHash);


### PR DESCRIPTION
```
curl --location 'https://eth-rpc-tc9.aca-staging.network' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "eth_call",
    "params": [
        {
            "data": "0x95d89b41",
            "gas": "0x2faf080",
            "to": "0xbcede5fd04cd6c08ca19d2f5193d6211ab3af5b7"
        },
        {
            "blockHash": "0xc422e7456709a217d364c2db0a3f202a9b6df02794ab5ca141e113719909b6f5"
        }
    ],
    "id": 1
}'
```
`{"jsonrpc":"2.0","error":{"code":-32603,"message":"execution error: outOfGas"},"id":1}`

If the eth_call request has a `gasLimit`, `substrateGas.gasLimit` is 0